### PR TITLE
fix: tolerate non-semver tags in changelog generation

### DIFF
--- a/CHANGELOG.long.md
+++ b/CHANGELOG.long.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-48 merges; 8 releases
+50 merges; 9 releases
 
 
 
@@ -12,8 +12,46 @@ All notable changes to this project will be documented in this file.
 
 Published tags:
 
-<a href="#1__6__4">1.6.4</a>, <a href="#1__6__3">1.6.3</a>, <a href="#1__6__2">1.6.2</a>, <a href="#1__6__1">1.6.1</a>, <a href="#1__6__0">1.6.0</a>, <a href="#1__5__0">1.5.0</a>, <a href="#1__4__1">1.4.1</a>, <a href="#1__0__0">1.0.0</a>
+<a href="#1__6__5">1.6.5</a>, <a href="#1__6__4">1.6.4</a>, <a href="#1__6__3">1.6.3</a>, <a href="#1__6__2">1.6.2</a>, <a href="#1__6__1">1.6.1</a>, <a href="#1__6__0">1.6.0</a>, <a href="#1__5__0">1.5.0</a>, <a href="#1__4__1">1.4.1</a>, <a href="#1__0__0">1.0.0</a>
 
+
+
+
+
+&nbsp;
+
+&nbsp;
+
+<a name="1__6__5" />
+
+## [1.6.5] - May 17, 2026 10:11:37 PM
+
+Commit [bf0422f736a08de7fb3aaa04a5010076d854d0c5](https://github.com/StoneCypher/better_git_changelog/commit/bf0422f736a08de7fb3aaa04a5010076d854d0c5)
+
+Author: `John Haugeland <stonecypher@gmail.com>`
+
+Merges [83f760f, 56638f0]
+
+  * Merge pull request #5 from StoneCypher/fix_26-05-17_commit-url_2
+  * fix: derive commit URLs from the git remote
+
+
+
+
+&nbsp;
+
+&nbsp;
+
+## [Untagged] - May 17, 2026 10:08:44 PM
+
+Commit [56638f08a775de1d034a63250a7b1f382ec80184](https://github.com/StoneCypher/better_git_changelog/commit/56638f08a775de1d034a63250a7b1f382ec80184)
+
+Author: `John Haugeland <stonecypher@gmail.com>`
+
+Merges [1e403b0, 83f760f]
+
+  * Merge origin/main into fix_26-05-17_commit-url_2
+  * PR #4 (CLI i18n) merged to main and also rewrote default_formatter. Conflict resolved: default_formatter is now (item, tr, repo_url) — both translator-aware (from the i18n work) and repo-URL-aware (this branch's issue #2 fix). Also untracks .claude/settings.local.json, a per-machine file committed by mistake, and adds it to .gitignore.
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-48 merges; 8 releases; Changelogging the last 10 commits; Full changelog at [CHANGELOG.long.md](CHANGELOG.long.md)
+50 merges; 9 releases; Changelogging the last 10 commits; Full changelog at [CHANGELOG.long.md](CHANGELOG.long.md)
 
 
 
@@ -12,8 +12,46 @@ All notable changes to this project will be documented in this file.
 
 Published tags:
 
-<a href="#1__6__4">1.6.4</a>, <a href="#1__6__3">1.6.3</a>, <a href="#1__6__2">1.6.2</a>, <a href="#1__6__1">1.6.1</a>, <a href="#1__6__0">1.6.0</a>, <a href="#1__5__0">1.5.0</a>, <a href="#1__4__1">1.4.1</a>, <a href="#1__0__0">1.0.0</a>
+<a href="#1__6__5">1.6.5</a>, <a href="#1__6__4">1.6.4</a>, <a href="#1__6__3">1.6.3</a>, <a href="#1__6__2">1.6.2</a>, <a href="#1__6__1">1.6.1</a>, <a href="#1__6__0">1.6.0</a>, <a href="#1__5__0">1.5.0</a>, <a href="#1__4__1">1.4.1</a>, <a href="#1__0__0">1.0.0</a>
 
+
+
+
+
+&nbsp;
+
+&nbsp;
+
+<a name="1__6__5" />
+
+## [1.6.5] - May 17, 2026 10:11:37 PM
+
+Commit [bf0422f736a08de7fb3aaa04a5010076d854d0c5](https://github.com/StoneCypher/better_git_changelog/commit/bf0422f736a08de7fb3aaa04a5010076d854d0c5)
+
+Author: `John Haugeland <stonecypher@gmail.com>`
+
+Merges [83f760f, 56638f0]
+
+  * Merge pull request #5 from StoneCypher/fix_26-05-17_commit-url_2
+  * fix: derive commit URLs from the git remote
+
+
+
+
+&nbsp;
+
+&nbsp;
+
+## [Untagged] - May 17, 2026 10:08:44 PM
+
+Commit [56638f08a775de1d034a63250a7b1f382ec80184](https://github.com/StoneCypher/better_git_changelog/commit/56638f08a775de1d034a63250a7b1f382ec80184)
+
+Author: `John Haugeland <stonecypher@gmail.com>`
+
+Merges [1e403b0, 83f760f]
+
+  * Merge origin/main into fix_26-05-17_commit-url_2
+  * PR #4 (CLI i18n) merged to main and also rewrote default_formatter. Conflict resolved: default_formatter is now (item, tr, repo_url) — both translator-aware (from the i18n work) and repo-URL-aware (this branch's issue #2 fix). Also untracks .claude/settings.local.json, a per-machine file committed by mistake, and adds it to .gitignore.
 
 
 
@@ -138,33 +176,3 @@ Commit [2f99467d3c1d2b8edd857b3c4299eeb0a91b81f0](https://github.com/StoneCypher
 Author: `John Haugeland <stonecypher@gmail.com>`
 
   * refactor: tidy the content translator and document its separator limit
-
-
-
-
-&nbsp;
-
-&nbsp;
-
-## [Untagged] - May 17, 2026 4:43:20 PM
-
-Commit [ab792e40c877124f18986cb1a0559aac195a96ac](https://github.com/StoneCypher/better_git_changelog/commit/ab792e40c877124f18986cb1a0559aac195a96ac)
-
-Author: `John Haugeland <stonecypher@gmail.com>`
-
-  * feat: add changelog content translator
-
-
-
-
-&nbsp;
-
-&nbsp;
-
-## [Untagged] - May 17, 2026 4:40:14 PM
-
-Commit [566da299044cdc589ebdb488ef2ce78e234a1653](https://github.com/StoneCypher/better_git_changelog/commit/566da299044cdc589ebdb488ef2ce78e234a1653)
-
-Author: `John Haugeland <stonecypher@gmail.com>`
-
-  * docs: document the localized rendering functions

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "better_git_changelog",
-  "version": "1.6.5",
+  "version": "1.6.6",
   "description": "Make a changelog from git commits, tags, and releases",
   "main": "src/js/index.js",
   "bin": {

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -27,12 +27,31 @@ function default_preface(t) {
 
 
 
+/**
+ * Comparator that orders tag names, tolerating non-semver tags.
+ *
+ * Two valid semver tags are compared by version precedence. A valid semver
+ * tag sorts before a non-semver one, and two non-semver tags are compared
+ * lexically — so a tag like `nightly` or `release-1` never throws.
+ *
+ * @param l  A tag name.
+ * @param r  A tag name.
+ * @returns  -1, 0, or 1, suitable for Array.prototype.sort.
+ *
+ * @example
+ *   ['2.0.0', 'nightly', '1.0.0'].sort(sem_sort);  // ['1.0.0','2.0.0','nightly']
+ */
 function sem_sort(l, r) {
-  return sv.lt(l, r)
-    ? -1
-    : (sv.gt(l, r)
-      ? 1
-      : 0);
+
+  const lv = sv.valid(l),
+        rv = sv.valid(r);
+
+  if (lv && rv) { return sv.lt(l, r) ? -1 : (sv.gt(l, r) ? 1 : 0); }
+  if (lv)       { return -1; }
+  if (rv)       { return 1; }
+
+  return (l < r) ? -1 : ((l > r) ? 1 : 0);
+
 }
 
 

--- a/src/js/test/formatter.test.js
+++ b/src/js/test/formatter.test.js
@@ -62,6 +62,15 @@ test('default_formatter renders a bare commit hash when no repo URL is known', (
   assert.doesNotMatch(md, /jssm/);
 });
 
+test('convert_to_md tolerates non-semver tags without throwing', () => {
+  const data = { reflog: [], tag_list: ['nightly', '1.0.0', '2.0.0'], tag_hashes: new Map() };
+  let md;
+  assert.doesNotThrow(() => { md = convert_to_md({ data }); });
+  assert.match(md, /nightly/);
+  assert.match(md, /1\.0\.0/);
+  assert.match(md, /2\.0\.0/);
+});
+
 function sampleData() {
   return {
     reflog: [


### PR DESCRIPTION
## Summary

`sem_sort` called `semver.lt`/`semver.gt` directly. Those throw `TypeError: Invalid Version` on any tag that is not valid semver, and `convert_to_md` sorts the whole tag list through `sem_sort` — so a single tag like `nightly`, `release-1`, or `v2-beta` crashed the entire run.

`sem_sort` now validates each operand first: two valid semver tags compare by version precedence, a valid tag sorts before a non-semver one, two non-semver tags compare lexically, and nothing throws.

## Test plan

- [ ] `npm test` — 50 pass, including the new 'convert_to_md tolerates non-semver tags without throwing'
- [ ] `npm run build` — succeeds

First of a stacked series of ten bug-fix PRs; each branches off the previous one.