### PR TITLE
fix: parse octopus merges with three or more parents

### DIFF
--- a/CHANGELOG.long.md
+++ b/CHANGELOG.long.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-50 merges; 9 releases
+51 merges; 9 releases
 
 
 
@@ -14,6 +14,22 @@ Published tags:
 
 <a href="#1__6__5">1.6.5</a>, <a href="#1__6__4">1.6.4</a>, <a href="#1__6__3">1.6.3</a>, <a href="#1__6__2">1.6.2</a>, <a href="#1__6__1">1.6.1</a>, <a href="#1__6__0">1.6.0</a>, <a href="#1__5__0">1.5.0</a>, <a href="#1__4__1">1.4.1</a>, <a href="#1__0__0">1.0.0</a>
 
+
+
+
+
+&nbsp;
+
+&nbsp;
+
+## [Untagged] - May 18, 2026 12:56:53 AM
+
+Commit [6673f2edea33d8298027baabc0c3403a15ee24a9](https://github.com/StoneCypher/better_git_changelog/commit/6673f2edea33d8298027baabc0c3403a15ee24a9)
+
+Author: `John Haugeland <stonecypher@gmail.com>`
+
+  * fix: tolerate non-semver tags in changelog generation
+  * sem_sort called semver.lt/gt directly, which throw on any tag that is not valid semver; convert_to_md sorts the tag list with it, so a single tag like 'nightly' crashed the whole run. sem_sort now validates first: valid semver tags compare by precedence, non-semver tags compare lexically and sort after, and nothing throws.
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-50 merges; 9 releases; Changelogging the last 10 commits; Full changelog at [CHANGELOG.long.md](CHANGELOG.long.md)
+51 merges; 9 releases; Changelogging the last 10 commits; Full changelog at [CHANGELOG.long.md](CHANGELOG.long.md)
 
 
 
@@ -14,6 +14,22 @@ Published tags:
 
 <a href="#1__6__5">1.6.5</a>, <a href="#1__6__4">1.6.4</a>, <a href="#1__6__3">1.6.3</a>, <a href="#1__6__2">1.6.2</a>, <a href="#1__6__1">1.6.1</a>, <a href="#1__6__0">1.6.0</a>, <a href="#1__5__0">1.5.0</a>, <a href="#1__4__1">1.4.1</a>, <a href="#1__0__0">1.0.0</a>
 
+
+
+
+
+&nbsp;
+
+&nbsp;
+
+## [Untagged] - May 18, 2026 12:56:53 AM
+
+Commit [6673f2edea33d8298027baabc0c3403a15ee24a9](https://github.com/StoneCypher/better_git_changelog/commit/6673f2edea33d8298027baabc0c3403a15ee24a9)
+
+Author: `John Haugeland <stonecypher@gmail.com>`
+
+  * fix: tolerate non-semver tags in changelog generation
+  * sem_sort called semver.lt/gt directly, which throw on any tag that is not valid semver; convert_to_md sorts the tag list with it, so a single tag like 'nightly' crashed the whole run. sem_sort now validates first: valid semver tags compare by precedence, non-semver tags compare lexically and sort after, and nothing throws.
 
 
 
@@ -161,18 +177,3 @@ Commit [aa56d69ad100a30c23475144c0a8e01ca66dcaf7](https://github.com/StoneCypher
 Author: `John Haugeland <stonecypher@gmail.com>`
 
   * feat: wire i18n into the CLI
-
-
-
-
-&nbsp;
-
-&nbsp;
-
-## [Untagged] - May 17, 2026 4:48:30 PM
-
-Commit [2f99467d3c1d2b8edd857b3c4299eeb0a91b81f0](https://github.com/StoneCypher/better_git_changelog/commit/2f99467d3c1d2b8edd857b3c4299eeb0a91b81f0)
-
-Author: `John Haugeland <stonecypher@gmail.com>`
-
-  * refactor: tidy the content translator and document its separator limit

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "better_git_changelog",
-  "version": "1.6.6",
+  "version": "1.6.7",
   "description": "Make a changelog from git commits, tags, and releases",
   "main": "src/js/index.js",
   "bin": {

--- a/src/js/reflog_parser.js
+++ b/src/js/reflog_parser.js
@@ -153,7 +153,9 @@ function peg$parse(input, options) {
       peg$c9 = peg$literalExpectation("Merge: ", false),
       peg$c10 = " ",
       peg$c11 = peg$literalExpectation(" ", false),
-      peg$c12 = function(hash1, hash2) { return [hash1, hash2]; },
+      peg$c12 = function(first, rest) {
+          return [first, ...rest.map(r => r[1])];
+        },
       peg$c13 = "Author: ",
       peg$c14 = peg$literalExpectation("Author: ", false),
       peg$c15 = /^[^\n]/,
@@ -685,7 +687,7 @@ function peg$parse(input, options) {
   }
 
   function peg$parseMergeRow() {
-    var s0, s1, s2, s3, s4, s5;
+    var s0, s1, s2, s3, s4, s5, s6;
 
     s0 = peg$currPos;
     if (input.substr(peg$currPos, 7) === peg$c8) {
@@ -698,31 +700,68 @@ function peg$parse(input, options) {
     if (s1 !== peg$FAILED) {
       s2 = peg$parseShortHash();
       if (s2 !== peg$FAILED) {
+        s3 = [];
+        s4 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 32) {
-          s3 = peg$c10;
+          s5 = peg$c10;
           peg$currPos++;
         } else {
-          s3 = peg$FAILED;
+          s5 = peg$FAILED;
           if (peg$silentFails === 0) { peg$fail(peg$c11); }
         }
-        if (s3 !== peg$FAILED) {
-          s4 = peg$parseShortHash();
-          if (s4 !== peg$FAILED) {
-            if (input.charCodeAt(peg$currPos) === 10) {
-              s5 = peg$c5;
+        if (s5 !== peg$FAILED) {
+          s6 = peg$parseShortHash();
+          if (s6 !== peg$FAILED) {
+            s5 = [s5, s6];
+            s4 = s5;
+          } else {
+            peg$currPos = s4;
+            s4 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s4;
+          s4 = peg$FAILED;
+        }
+        if (s4 !== peg$FAILED) {
+          while (s4 !== peg$FAILED) {
+            s3.push(s4);
+            s4 = peg$currPos;
+            if (input.charCodeAt(peg$currPos) === 32) {
+              s5 = peg$c10;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c6); }
+              if (peg$silentFails === 0) { peg$fail(peg$c11); }
             }
             if (s5 !== peg$FAILED) {
-              peg$savedPos = s0;
-              s1 = peg$c12(s2, s4);
-              s0 = s1;
+              s6 = peg$parseShortHash();
+              if (s6 !== peg$FAILED) {
+                s5 = [s5, s6];
+                s4 = s5;
+              } else {
+                peg$currPos = s4;
+                s4 = peg$FAILED;
+              }
             } else {
-              peg$currPos = s0;
-              s0 = peg$FAILED;
+              peg$currPos = s4;
+              s4 = peg$FAILED;
             }
+          }
+        } else {
+          s3 = peg$FAILED;
+        }
+        if (s3 !== peg$FAILED) {
+          if (input.charCodeAt(peg$currPos) === 10) {
+            s4 = peg$c5;
+            peg$currPos++;
+          } else {
+            s4 = peg$FAILED;
+            if (peg$silentFails === 0) { peg$fail(peg$c6); }
+          }
+          if (s4 !== peg$FAILED) {
+            peg$savedPos = s0;
+            s1 = peg$c12(s2, s3);
+            s0 = s1;
           } else {
             peg$currPos = s0;
             s0 = peg$FAILED;

--- a/src/js/test/parser.test.js
+++ b/src/js/test/parser.test.js
@@ -44,3 +44,18 @@ test('exactly the fixture\'s 92 merge commits carry a merge array', () => {
   const merges = reflog.filter(e => e.merge !== undefined);
   assert.strictEqual(merges.length, 92);
 });
+
+test('parse_rl handles an octopus merge (three or more parents)', () => {
+  const octopus =
+    'commit 1111111111111111111111111111111111111111\n' +
+    'Merge: aaaaaaa bbbbbbb ccccccc\n' +
+    'Author: A <a@example.com>\n' +
+    'Date:   Sun May 18 12:00:00 2026 -0700\n' +
+    '\n' +
+    '    octopus merge\n' +
+    '\n';
+  let parsed;
+  assert.doesNotThrow(() => { parsed = parse_rl(octopus); });
+  assert.strictEqual(parsed.length, 1);
+  assert.deepStrictEqual(parsed[0].merge, ['aaaaaaa', 'bbbbbbb', 'ccccccc']);
+});

--- a/src/peg/reflog_parser.peg
+++ b/src/peg/reflog_parser.peg
@@ -16,7 +16,9 @@ CommitRow
   = 'commit ' hash:Hash '\n' { return hash; }
 
 MergeRow
-  = 'Merge: ' hash1:ShortHash ' ' hash2:ShortHash '\n' { return [hash1, hash2]; }
+  = 'Merge: ' first:ShortHash rest:(' ' ShortHash)+ '\n' {
+    return [first, ...rest.map(r => r[1])];
+  }
 
 AuthorRow
   = 'Author: ' author:[^\n]* '\n' { return author.join(''); }


### PR DESCRIPTION
## Summary

The PEG grammar's `MergeRow` matched exactly two parent hashes (`'Merge: ' hash1 ' ' hash2`), so a merge commit with three or more parents — an octopus merge — failed to parse and `parse_rl` threw, crashing the run on any repo containing one.

`MergeRow` now matches one parent followed by one-or-more additional parents and returns the full list. Two-parent merges are unaffected (the existing fixture-merge tests still pass). The regenerated `reflog_parser.js` is committed.

## Test plan

- [ ] `npm test` — 51 pass, including the new octopus-merge test
- [ ] `npm run build` — succeeds

Bug 2 of 10. Stacked on #6 (this PR's base is `fix_26-05-18_non-semver-tags`).