### PR TITLE
fix: honor the item_separator option in convert_to_md

### DIFF
--- a/CHANGELOG.long.md
+++ b/CHANGELOG.long.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-51 merges; 9 releases
+52 merges; 9 releases
 
 
 
@@ -14,6 +14,22 @@ Published tags:
 
 <a href="#1__6__5">1.6.5</a>, <a href="#1__6__4">1.6.4</a>, <a href="#1__6__3">1.6.3</a>, <a href="#1__6__2">1.6.2</a>, <a href="#1__6__1">1.6.1</a>, <a href="#1__6__0">1.6.0</a>, <a href="#1__5__0">1.5.0</a>, <a href="#1__4__1">1.4.1</a>, <a href="#1__0__0">1.0.0</a>
 
+
+
+
+
+&nbsp;
+
+&nbsp;
+
+## [Untagged] - May 18, 2026 7:00:47 AM
+
+Commit [e23fbdc457ca77fbfdab56de1fc25c346f1067d8](https://github.com/StoneCypher/better_git_changelog/commit/e23fbdc457ca77fbfdab56de1fc25c346f1067d8)
+
+Author: `John Haugeland <stonecypher@gmail.com>`
+
+  * fix: parse octopus merges with three or more parents
+  * The PEG grammar's MergeRow accepted exactly two parent hashes, so a merge commit with 3+ parents (an octopus merge) failed to parse and crashed parse_rl. MergeRow now accepts one parent followed by one or more additional parents, returning the full list. The regenerated reflog_parser.js is included.
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-51 merges; 9 releases; Changelogging the last 10 commits; Full changelog at [CHANGELOG.long.md](CHANGELOG.long.md)
+52 merges; 9 releases; Changelogging the last 10 commits; Full changelog at [CHANGELOG.long.md](CHANGELOG.long.md)
 
 
 
@@ -14,6 +14,22 @@ Published tags:
 
 <a href="#1__6__5">1.6.5</a>, <a href="#1__6__4">1.6.4</a>, <a href="#1__6__3">1.6.3</a>, <a href="#1__6__2">1.6.2</a>, <a href="#1__6__1">1.6.1</a>, <a href="#1__6__0">1.6.0</a>, <a href="#1__5__0">1.5.0</a>, <a href="#1__4__1">1.4.1</a>, <a href="#1__0__0">1.0.0</a>
 
+
+
+
+
+&nbsp;
+
+&nbsp;
+
+## [Untagged] - May 18, 2026 7:00:47 AM
+
+Commit [e23fbdc457ca77fbfdab56de1fc25c346f1067d8](https://github.com/StoneCypher/better_git_changelog/commit/e23fbdc457ca77fbfdab56de1fc25c346f1067d8)
+
+Author: `John Haugeland <stonecypher@gmail.com>`
+
+  * fix: parse octopus merges with three or more parents
+  * The PEG grammar's MergeRow accepted exactly two parent hashes, so a merge commit with 3+ parents (an octopus merge) failed to parse and crashed parse_rl. MergeRow now accepts one parent followed by one or more additional parents, returning the full list. The regenerated reflog_parser.js is included.
 
 
 
@@ -162,18 +178,3 @@ Commit [be7171150cdbbdd4c8d125b7cd65203fa5fd6306](https://github.com/StoneCypher
 Author: `John Haugeland <stonecypher@gmail.com>`
 
   * fix: stop duplicate CLI error output and honor --ui-lang=fr form
-
-
-
-
-&nbsp;
-
-&nbsp;
-
-## [Untagged] - May 17, 2026 4:51:07 PM
-
-Commit [aa56d69ad100a30c23475144c0a8e01ca66dcaf7](https://github.com/StoneCypher/better_git_changelog/commit/aa56d69ad100a30c23475144c0a8e01ca66dcaf7)
-
-Author: `John Haugeland <stonecypher@gmail.com>`
-
-  * feat: wire i18n into the CLI

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "better_git_changelog",
-  "version": "1.6.7",
+  "version": "1.6.8",
   "description": "Make a changelog from git commits, tags, and releases",
   "main": "src/js/index.js",
   "bin": {

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -445,7 +445,7 @@ function convert_to_md({ target, data, item_formatter, item_separator, preface, 
   const urefs = is_short ? data.reflog.slice(0, use_sl) : data.reflog;
 
   urefs.forEach( (rli) => {
-    md += default_separator(rli);
+    md += separator(rli);
     md += formatter(rli, tr, data.repo_url);
   } );
 

--- a/src/js/test/formatter.test.js
+++ b/src/js/test/formatter.test.js
@@ -71,6 +71,11 @@ test('convert_to_md tolerates non-semver tags without throwing', () => {
   assert.match(md, /2\.0\.0/);
 });
 
+test('convert_to_md honors a custom item_separator', () => {
+  const md = convert_to_md({ data: sampleData(), item_separator: () => '\n===CUSTOMSEP===\n' });
+  assert.match(md, /===CUSTOMSEP===/);
+});
+
 function sampleData() {
   return {
     reflog: [


### PR DESCRIPTION
## Summary

`convert_to_md` resolved `separator = item_separator || default_separator`, but the render loop then called `default_separator(rli)` directly — so a caller-supplied `item_separator` was silently ignored and the resolved `separator` variable was dead.

The loop now calls the resolved `separator`. Default behavior is unchanged (it still falls back to `default_separator`).

## Test plan

- [ ] `npm test` — 52 pass, including the new custom-item_separator test
- [ ] `npm run build` — succeeds

Bug 3 of 10. Stacked on #7 (base `fix_26-05-18_octopus-merge`).