### PR TITLE
fix: remove shell-injection risk in tag_to_hash

### DIFF
--- a/CHANGELOG.long.md
+++ b/CHANGELOG.long.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-52 merges; 9 releases
+53 merges; 9 releases
 
 
 
@@ -14,6 +14,22 @@ Published tags:
 
 <a href="#1__6__5">1.6.5</a>, <a href="#1__6__4">1.6.4</a>, <a href="#1__6__3">1.6.3</a>, <a href="#1__6__2">1.6.2</a>, <a href="#1__6__1">1.6.1</a>, <a href="#1__6__0">1.6.0</a>, <a href="#1__5__0">1.5.0</a>, <a href="#1__4__1">1.4.1</a>, <a href="#1__0__0">1.0.0</a>
 
+
+
+
+
+&nbsp;
+
+&nbsp;
+
+## [Untagged] - May 18, 2026 7:05:59 AM
+
+Commit [6e689419cfad9725f255c8b3a69506bbfdb53557](https://github.com/StoneCypher/better_git_changelog/commit/6e689419cfad9725f255c8b3a69506bbfdb53557)
+
+Author: `John Haugeland <stonecypher@gmail.com>`
+
+  * fix: honor the item_separator option in convert_to_md
+  * convert_to_md resolved separator = item_separator || default_separator but the render loop then called default_separator directly, so a caller-supplied item_separator was silently ignored. The loop now calls the resolved separator.
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-52 merges; 9 releases; Changelogging the last 10 commits; Full changelog at [CHANGELOG.long.md](CHANGELOG.long.md)
+53 merges; 9 releases; Changelogging the last 10 commits; Full changelog at [CHANGELOG.long.md](CHANGELOG.long.md)
 
 
 
@@ -14,6 +14,22 @@ Published tags:
 
 <a href="#1__6__5">1.6.5</a>, <a href="#1__6__4">1.6.4</a>, <a href="#1__6__3">1.6.3</a>, <a href="#1__6__2">1.6.2</a>, <a href="#1__6__1">1.6.1</a>, <a href="#1__6__0">1.6.0</a>, <a href="#1__5__0">1.5.0</a>, <a href="#1__4__1">1.4.1</a>, <a href="#1__0__0">1.0.0</a>
 
+
+
+
+
+&nbsp;
+
+&nbsp;
+
+## [Untagged] - May 18, 2026 7:05:59 AM
+
+Commit [6e689419cfad9725f255c8b3a69506bbfdb53557](https://github.com/StoneCypher/better_git_changelog/commit/6e689419cfad9725f255c8b3a69506bbfdb53557)
+
+Author: `John Haugeland <stonecypher@gmail.com>`
+
+  * fix: honor the item_separator option in convert_to_md
+  * convert_to_md resolved separator = item_separator || default_separator but the render loop then called default_separator directly, so a caller-supplied item_separator was silently ignored. The loop now calls the resolved separator.
 
 
 
@@ -163,18 +179,3 @@ Commit [0f59cbe32c9564de264d5f83b963c01eb3181b3f](https://github.com/StoneCypher
 Author: `John Haugeland <stonecypher@gmail.com>`
 
   * docs: document CLI internationalization
-
-
-
-
-&nbsp;
-
-&nbsp;
-
-## [Untagged] - May 17, 2026 5:07:03 PM
-
-Commit [be7171150cdbbdd4c8d125b7cd65203fa5fd6306](https://github.com/StoneCypher/better_git_changelog/commit/be7171150cdbbdd4c8d125b7cd65203fa5fd6306)
-
-Author: `John Haugeland <stonecypher@gmail.com>`
-
-  * fix: stop duplicate CLI error output and honor --ui-lang=fr form

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "better_git_changelog",
-  "version": "1.6.8",
+  "version": "1.6.9",
   "description": "Make a changelog from git commits, tags, and releases",
   "main": "src/js/index.js",
   "bin": {

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -73,9 +73,21 @@ function get_tag_list() {
 
 
 
+/**
+ * Resolve a tag name to the hash of the commit it points at.
+ *
+ * Spawned shell-free with execFileSync, so a tag name containing shell
+ * metacharacters cannot be reinterpreted by a shell.
+ *
+ * @param tag  A git tag name.
+ * @returns The commit hash the tag resolves to.
+ *
+ * @example
+ *   tag_to_hash('1.6.8');   // 'a1b2c3d4...'
+ */
 function tag_to_hash(tag) {
 
-  return cp.execSync(`git rev-list -n 1 ${tag}`)
+  return cp.execFileSync('git', [ 'rev-list', '-n', '1', tag ])
     .toString()
     .trim();
 

--- a/src/js/test/integration.test.js
+++ b/src/js/test/integration.test.js
@@ -40,6 +40,13 @@ test('tag_to_hash resolves a real tag to a 40-char hash, when tags exist', () =>
   assert.match(api.tag_to_hash(tags[0]), /^[a-fA-F0-9]{40}$/);
 });
 
+test('tag_to_hash does not let a tag name reach the shell', () => {
+  // With execFileSync the whole string is a single git argument (an unknown
+  // ref), so git fails and execFileSync throws. The old shell form would have
+  // run the trailing `; echo ...` and returned its output instead of throwing.
+  assert.throws(() => api.tag_to_hash('no-such-ref; echo shell-injection'));
+});
+
 test('tags_to_hashes maps every distinct tag to a hash', () => {
   const tags   = api.get_tag_list();
   const hashes = api.tags_to_hashes(tags);


### PR DESCRIPTION
## Summary

`tag_to_hash` interpolated the tag name into a shell command string passed to `execSync` (`git rev-list -n 1 ${tag}`). Git tag names may legally contain shell metacharacters (`$`, backtick, `;`, `|`, `(`, `)`), so a hostile tag in a repository could execute arbitrary commands when the tool runs.

It now uses `execFileSync` with an argument array — no shell is involved, and the tag is a single literal argument.

`get_commit_message_for_hash` has the same interpolation pattern but is dead code (unused, unexported); it is removed in PR for bug 8 of this series rather than patched here.

## Test plan

- [ ] `npm test` — 53 pass, including the new 'tag_to_hash does not let a tag name reach the shell' test
- [ ] `npm run build` — succeeds

Bug 4 of 10. Stacked on #8 (base `fix_26-05-18_item-separator`).