### PR TITLE
fix: keep every tag when a commit has more than one

### DIFF
--- a/CHANGELOG.long.md
+++ b/CHANGELOG.long.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-55 merges; 9 releases
+56 merges; 9 releases
 
 
 
@@ -14,6 +14,22 @@ Published tags:
 
 <a href="#1__6__5">1.6.5</a>, <a href="#1__6__4">1.6.4</a>, <a href="#1__6__3">1.6.3</a>, <a href="#1__6__2">1.6.2</a>, <a href="#1__6__1">1.6.1</a>, <a href="#1__6__0">1.6.0</a>, <a href="#1__5__0">1.5.0</a>, <a href="#1__4__1">1.4.1</a>, <a href="#1__0__0">1.0.0</a>
 
+
+
+
+
+&nbsp;
+
+&nbsp;
+
+## [Untagged] - May 18, 2026 9:01:30 AM
+
+Commit [02861f9b9ed1dacccb59c87338dc9f53077e6838](https://github.com/StoneCypher/better_git_changelog/commit/02861f9b9ed1dacccb59c87338dc9f53077e6838)
+
+Author: `John Haugeland <stonecypher@gmail.com>`
+
+  * fix: stop convert_to_md from mutating the caller's tag_list
+  * convert_to_md sorted data.tag_list with Array.prototype.sort, which sorts in place — so it reordered the caller's array (the scan() result) as a side effect. It now sorts a copy.
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-55 merges; 9 releases; Changelogging the last 10 commits; Full changelog at [CHANGELOG.long.md](CHANGELOG.long.md)
+56 merges; 9 releases; Changelogging the last 10 commits; Full changelog at [CHANGELOG.long.md](CHANGELOG.long.md)
 
 
 
@@ -14,6 +14,22 @@ Published tags:
 
 <a href="#1__6__5">1.6.5</a>, <a href="#1__6__4">1.6.4</a>, <a href="#1__6__3">1.6.3</a>, <a href="#1__6__2">1.6.2</a>, <a href="#1__6__1">1.6.1</a>, <a href="#1__6__0">1.6.0</a>, <a href="#1__5__0">1.5.0</a>, <a href="#1__4__1">1.4.1</a>, <a href="#1__0__0">1.0.0</a>
 
+
+
+
+
+&nbsp;
+
+&nbsp;
+
+## [Untagged] - May 18, 2026 9:01:30 AM
+
+Commit [02861f9b9ed1dacccb59c87338dc9f53077e6838](https://github.com/StoneCypher/better_git_changelog/commit/02861f9b9ed1dacccb59c87338dc9f53077e6838)
+
+Author: `John Haugeland <stonecypher@gmail.com>`
+
+  * fix: stop convert_to_md from mutating the caller's tag_list
+  * convert_to_md sorted data.tag_list with Array.prototype.sort, which sorts in place — so it reordered the caller's array (the scan() result) as a side effect. It now sorts a copy.
 
 
 
@@ -166,18 +182,3 @@ Merges [64587df, 297f6da]
 
   * Merge pull request #4 from StoneCypher/feat_26-05-17_cli-i18n
   * feat: internationalize the CLI with twelve languages
-
-
-
-
-&nbsp;
-
-&nbsp;
-
-## [Untagged] - May 17, 2026 9:18:31 PM
-
-Commit [297f6da977a247f7711b36165287511e4f57387c](https://github.com/StoneCypher/better_git_changelog/commit/297f6da977a247f7711b36165287511e4f57387c)
-
-Author: `John Haugeland <stonecypher@gmail.com>`
-
-  * change node versions supported in ci/cd

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "better_git_changelog",
-  "version": "1.6.11",
+  "version": "1.6.12",
   "description": "Make a changelog from git commits, tags, and releases",
   "main": "src/js/index.js",
   "bin": {

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -277,7 +277,7 @@ function scan() {
       not_found.push(tag);
     } else {
       found.push(tag);
-      reflog[idx].tag = tag;
+      ( reflog[idx].tag || (reflog[idx].tag = []) ).push(tag);
     }
 
   } );
@@ -331,7 +331,8 @@ function slug(text) {
  * Render one parsed reflog entry as a Markdown changelog section.
  *
  * @param item      A reflog entry: `commit_hash` and `commit_text`, plus the
- *                  optional `tag`, `date`, `author`, and `merge` fields.
+ *                  optional `tag` (a tag name, or an array of tag names when a
+ *                  commit carries several), `date`, `author`, and `merge`.
  * @param tr        A translator from i18n.make_translator; defaults to English.
  * @param repo_url  The repository's web base URL. When given, the commit hash
  *                  is linked to `<repo_url>/commit/<hash>`; when absent, the
@@ -346,16 +347,20 @@ function default_formatter(item, tr, repo_url) {
   const t = tr.t;
   const d = item.date ? new Date(item.date) : null;
 
+  const tags = item.tag
+    ? (Array.isArray(item.tag) ? item.tag : [item.tag])
+    : [];
+
   return `${
 
-    item.tag
-      ? `<a name="${slug(item.tag)}" />\n\n`
+    tags.length
+      ? tags.map(tg => `<a name="${slug(tg)}" />`).join('\n\n') + '\n\n'
       : ''
 
   }##${
 
-    item.tag
-      ? ` [${item.tag}]`
+    tags.length
+      ? tags.map(tg => ` [${tg}]`).join('')
       : ` [${t('changelog', 'untagged')}]`
 
   }${

--- a/src/js/test/formatter.test.js
+++ b/src/js/test/formatter.test.js
@@ -83,6 +83,13 @@ test('convert_to_md does not mutate the caller\'s tag_list', () => {
   assert.deepStrictEqual(data.tag_list, before);
 });
 
+test('default_formatter renders every tag on a multiply-tagged commit', () => {
+  const md = default_formatter({ tag: ['1.0.0', 'stable'], commit_hash: 'abc', commit_text: ['m'] });
+  assert.match(md, /## \[1\.0\.0\] \[stable\]/);
+  assert.match(md, /<a name="1__0__0" \/>/);
+  assert.match(md, /<a name="stable" \/>/);
+});
+
 function sampleData() {
   return {
     reflog: [


### PR DESCRIPTION
## Summary

`scan()` stamped each matched tag with `reflog[idx].tag = tag`. When several tags pointed at the same commit, each assignment overwrote the previous one, so only the last-processed tag survived into the changelog.

`scan()` now collects a commit's tags into an array. `default_formatter` accepts either a single tag (string) or an array — it emits an anchor per tag and lists them all in the section heading (`## [1.0.0] [stable]`), so every tag's entry in the "Published tags" index still resolves to an anchor.

## Test plan

- [ ] `npm test` — 56 pass, including the new multiply-tagged-commit test
- [ ] `npm run build` — succeeds

Bug 7 of 10. Stacked on #11 (base `fix_26-05-18_tag-list-mutation`).