### PR TITLE
fix: reject a non-numeric --short-length instead of emptying the changelog

### DIFF
--- a/CHANGELOG.long.md
+++ b/CHANGELOG.long.md
@@ -22,6 +22,22 @@ Published tags:
 
 &nbsp;
 
+## [Untagged] - May 18, 2026 9:55:25 AM
+
+Commit [c5e90a724cdf065a41b7a08b6db20755d8b7a3f4](https://github.com/StoneCypher/better_git_changelog/commit/c5e90a724cdf065a41b7a08b6db20755d8b7a3f4)
+
+Author: `John Haugeland <stonecypher@gmail.com>`
+
+  * fix: count merge commits, not all commits, in the summary line
+  * The changelog summary rendered data.reflog.length through the 'merges' string, so it reported every commit as a merge (e.g. '441 merges' when 441 was the total entry count). It now counts only entries that actually carry a merge field.
+
+
+
+
+&nbsp;
+
+&nbsp;
+
 ## [Untagged] - May 18, 2026 9:48:07 AM
 
 Commit [1025797c006f88bb9f724467a9c636729cd22254](https://github.com/StoneCypher/better_git_changelog/commit/1025797c006f88bb9f724467a9c636729cd22254)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,22 @@ Published tags:
 
 &nbsp;
 
+## [Untagged] - May 18, 2026 9:55:25 AM
+
+Commit [c5e90a724cdf065a41b7a08b6db20755d8b7a3f4](https://github.com/StoneCypher/better_git_changelog/commit/c5e90a724cdf065a41b7a08b6db20755d8b7a3f4)
+
+Author: `John Haugeland <stonecypher@gmail.com>`
+
+  * fix: count merge commits, not all commits, in the summary line
+  * The changelog summary rendered data.reflog.length through the 'merges' string, so it reported every commit as a merge (e.g. '441 merges' when 441 was the total entry count). It now counts only entries that actually carry a merge field.
+
+
+
+
+&nbsp;
+
+&nbsp;
+
 ## [Untagged] - May 18, 2026 9:48:07 AM
 
 Commit [1025797c006f88bb9f724467a9c636729cd22254](https://github.com/StoneCypher/better_git_changelog/commit/1025797c006f88bb9f724467a9c636729cd22254)
@@ -162,21 +178,3 @@ Merges [83f760f, 56638f0]
 
   * Merge pull request #5 from StoneCypher/fix_26-05-17_commit-url_2
   * fix: derive commit URLs from the git remote
-
-
-
-
-&nbsp;
-
-&nbsp;
-
-## [Untagged] - May 17, 2026 10:08:44 PM
-
-Commit [56638f08a775de1d034a63250a7b1f382ec80184](https://github.com/StoneCypher/better_git_changelog/commit/56638f08a775de1d034a63250a7b1f382ec80184)
-
-Author: `John Haugeland <stonecypher@gmail.com>`
-
-Merges [1e403b0, 83f760f]
-
-  * Merge origin/main into fix_26-05-17_commit-url_2
-  * PR #4 (CLI i18n) merged to main and also rewrote default_formatter. Conflict resolved: default_formatter is now (item, tr, repo_url) — both translator-aware (from the i18n work) and repo-URL-aware (this branch's issue #2 fix). Also untracks .claude/settings.local.json, a per-machine file committed by mistake, and adds it to .gitignore.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "better_git_changelog",
-  "version": "1.6.14",
+  "version": "1.6.15",
   "description": "Make a changelog from git commits, tags, and releases",
   "main": "src/js/index.js",
   "bin": {

--- a/src/js/cli.js
+++ b/src/js/cli.js
@@ -3,7 +3,20 @@
 const api  = require('./index.js');
 const i18n = require('./i18n.js');
 
-const { program } = require('commander');
+const { program, InvalidArgumentError } = require('commander');
+
+
+
+// Coerce and validate the -S/--short-length value: a positive integer.
+// An invalid value raises InvalidArgumentError so commander rejects the
+// run, instead of silently producing an empty changelog from slice(0, NaN).
+function parse_short_length(value) {
+  const n = Number(value);
+  if (!Number.isInteger(n) || n < 1) {
+    throw new InvalidArgumentError('must be a positive integer.');
+  }
+  return n;
+}
 
 
 
@@ -32,7 +45,7 @@ program
   .helpOption('-h, --help', ut('ui', 'optHelp'))
   .option('-l, --long-form',             ut('ui', 'optLongForm'))
   .option('-s, --short-form',            ut('ui', 'optShortForm'))
-  .option('-S, --short-length <count>',  ut('ui', 'optShortLength'))
+  .option('-S, --short-length <count>',  ut('ui', 'optShortLength'), parse_short_length)
   .option('-b, --both-forms [filename]', ut('ui', 'optBothForms'))
   .option('-f, --filename <filename>',   ut('ui', 'optFilename'), 'CHANGELOG.md')
   .option('-u, --ui-lang <code>',        ut('ui', 'optUiLang'))

--- a/src/js/test/integration.test.js
+++ b/src/js/test/integration.test.js
@@ -76,6 +76,13 @@ test('write_short_md writes a truncated changelog file', () => {
   }
 });
 
+test('the CLI rejects a non-numeric --short-length instead of emptying the changelog', () => {
+  const child = require('node:child_process');
+  const cli   = path.join(__dirname, '..', 'cli.js');
+  const r     = child.spawnSync('node', [cli, '-S', 'abc'], { encoding: 'utf8' });
+  assert.notStrictEqual(r.status, 0);   // exits non-zero rather than silently succeeding
+});
+
 test('convert_to_json writes parseable JSON', () => {
   const target = tempPath('json', 'json');
   try {


### PR DESCRIPTION
## Summary

`opts.shortLength` was an unvalidated string straight from commander. `-S abc` flowed into `data.reflog.slice(0, Number('abc'))` — i.e. `slice(0, NaN)` — which silently produced an **empty** changelog with no error.

`-S` now has a commander argument parser that coerces the value to a positive integer and raises `InvalidArgumentError` on anything else, so a bad value fails the run loudly. It also makes `opts.shortLength` a real number rather than a string.

## Test plan

- [ ] `npm test` — 58 pass, including the new 'CLI rejects a non-numeric --short-length' test
- [ ] `npm run build` — succeeds

Bug 10 of 10 — the last in the series. Stacked on #14 (base `fix_26-05-18_merge-count`).