### PR TITLE
fix: land bug fixes 2-10 on main

### DIFF
--- a/CHANGELOG.long.md
+++ b/CHANGELOG.long.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-52 merges; 9 releases
+53 merges; 9 releases
 
 
 
@@ -14,6 +14,22 @@ Published tags:
 
 <a href="#1__6__5">1.6.5</a>, <a href="#1__6__4">1.6.4</a>, <a href="#1__6__3">1.6.3</a>, <a href="#1__6__2">1.6.2</a>, <a href="#1__6__1">1.6.1</a>, <a href="#1__6__0">1.6.0</a>, <a href="#1__5__0">1.5.0</a>, <a href="#1__4__1">1.4.1</a>, <a href="#1__0__0">1.0.0</a>
 
+
+
+
+
+&nbsp;
+
+&nbsp;
+
+## [Untagged] - May 18, 2026 7:05:59 AM
+
+Commit [6e689419cfad9725f255c8b3a69506bbfdb53557](https://github.com/StoneCypher/better_git_changelog/commit/6e689419cfad9725f255c8b3a69506bbfdb53557)
+
+Author: `John Haugeland <stonecypher@gmail.com>`
+
+  * fix: honor the item_separator option in convert_to_md
+  * convert_to_md resolved separator = item_separator || default_separator but the render loop then called default_separator directly, so a caller-supplied item_separator was silently ignored. The loop now calls the resolved separator.
 
 
 

--- a/CHANGELOG.long.md
+++ b/CHANGELOG.long.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-56 merges; 9 releases
+57 merges; 9 releases
 
 
 
@@ -14,6 +14,22 @@ Published tags:
 
 <a href="#1__6__5">1.6.5</a>, <a href="#1__6__4">1.6.4</a>, <a href="#1__6__3">1.6.3</a>, <a href="#1__6__2">1.6.2</a>, <a href="#1__6__1">1.6.1</a>, <a href="#1__6__0">1.6.0</a>, <a href="#1__5__0">1.5.0</a>, <a href="#1__4__1">1.4.1</a>, <a href="#1__0__0">1.0.0</a>
 
+
+
+
+
+&nbsp;
+
+&nbsp;
+
+## [Untagged] - May 18, 2026 9:45:29 AM
+
+Commit [fce0d5b67f5895be5bbb180cfaaed32f885eeb5e](https://github.com/StoneCypher/better_git_changelog/commit/fce0d5b67f5895be5bbb180cfaaed32f885eeb5e)
+
+Author: `John Haugeland <stonecypher@gmail.com>`
+
+  * fix: keep every tag when a commit has more than one
+  * scan() did reflog[idx].tag = tag, so when several tags pointed at the same commit each assignment overwrote the previous and only the last survived. scan() now collects them into an array. default_formatter accepts either a single tag or an array, emitting an anchor per tag and listing them all in the heading, so every tag's index link still resolves.
 
 
 

--- a/CHANGELOG.long.md
+++ b/CHANGELOG.long.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-55 merges; 9 releases
+56 merges; 9 releases
 
 
 
@@ -14,6 +14,22 @@ Published tags:
 
 <a href="#1__6__5">1.6.5</a>, <a href="#1__6__4">1.6.4</a>, <a href="#1__6__3">1.6.3</a>, <a href="#1__6__2">1.6.2</a>, <a href="#1__6__1">1.6.1</a>, <a href="#1__6__0">1.6.0</a>, <a href="#1__5__0">1.5.0</a>, <a href="#1__4__1">1.4.1</a>, <a href="#1__0__0">1.0.0</a>
 
+
+
+
+
+&nbsp;
+
+&nbsp;
+
+## [Untagged] - May 18, 2026 9:01:30 AM
+
+Commit [02861f9b9ed1dacccb59c87338dc9f53077e6838](https://github.com/StoneCypher/better_git_changelog/commit/02861f9b9ed1dacccb59c87338dc9f53077e6838)
+
+Author: `John Haugeland <stonecypher@gmail.com>`
+
+  * fix: stop convert_to_md from mutating the caller's tag_list
+  * convert_to_md sorted data.tag_list with Array.prototype.sort, which sorts in place — so it reordered the caller's array (the scan() result) as a side effect. It now sorts a copy.
 
 
 

--- a/CHANGELOG.long.md
+++ b/CHANGELOG.long.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-57 merges; 9 releases
+4 merges; 9 releases
 
 
 
@@ -14,6 +14,22 @@ Published tags:
 
 <a href="#1__6__5">1.6.5</a>, <a href="#1__6__4">1.6.4</a>, <a href="#1__6__3">1.6.3</a>, <a href="#1__6__2">1.6.2</a>, <a href="#1__6__1">1.6.1</a>, <a href="#1__6__0">1.6.0</a>, <a href="#1__5__0">1.5.0</a>, <a href="#1__4__1">1.4.1</a>, <a href="#1__0__0">1.0.0</a>
 
+
+
+
+
+&nbsp;
+
+&nbsp;
+
+## [Untagged] - May 18, 2026 9:48:07 AM
+
+Commit [1025797c006f88bb9f724467a9c636729cd22254](https://github.com/StoneCypher/better_git_changelog/commit/1025797c006f88bb9f724467a9c636729cd22254)
+
+Author: `John Haugeland <stonecypher@gmail.com>`
+
+  * refactor: remove dead get_commit_message_for_hash
+  * get_commit_message_for_hash was never called and never exported, so it was unreachable code — and it carried the same string-interpolated execSync injection pattern that was fixed in tag_to_hash. Removing it eliminates both. No test accompanies this change because there was nothing reachable to test; the existing suite still passes, confirming nothing depended on it.
 
 
 

--- a/CHANGELOG.long.md
+++ b/CHANGELOG.long.md
@@ -22,6 +22,22 @@ Published tags:
 
 &nbsp;
 
+## [Untagged] - May 18, 2026 9:55:25 AM
+
+Commit [c5e90a724cdf065a41b7a08b6db20755d8b7a3f4](https://github.com/StoneCypher/better_git_changelog/commit/c5e90a724cdf065a41b7a08b6db20755d8b7a3f4)
+
+Author: `John Haugeland <stonecypher@gmail.com>`
+
+  * fix: count merge commits, not all commits, in the summary line
+  * The changelog summary rendered data.reflog.length through the 'merges' string, so it reported every commit as a merge (e.g. '441 merges' when 441 was the total entry count). It now counts only entries that actually carry a merge field.
+
+
+
+
+&nbsp;
+
+&nbsp;
+
 ## [Untagged] - May 18, 2026 9:48:07 AM
 
 Commit [1025797c006f88bb9f724467a9c636729cd22254](https://github.com/StoneCypher/better_git_changelog/commit/1025797c006f88bb9f724467a9c636729cd22254)

--- a/CHANGELOG.long.md
+++ b/CHANGELOG.long.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-53 merges; 9 releases
+54 merges; 9 releases
 
 
 
@@ -14,6 +14,22 @@ Published tags:
 
 <a href="#1__6__5">1.6.5</a>, <a href="#1__6__4">1.6.4</a>, <a href="#1__6__3">1.6.3</a>, <a href="#1__6__2">1.6.2</a>, <a href="#1__6__1">1.6.1</a>, <a href="#1__6__0">1.6.0</a>, <a href="#1__5__0">1.5.0</a>, <a href="#1__4__1">1.4.1</a>, <a href="#1__0__0">1.0.0</a>
 
+
+
+
+
+&nbsp;
+
+&nbsp;
+
+## [Untagged] - May 18, 2026 7:12:46 AM
+
+Commit [70f1c013dcc7120b3565b4ca1ba4691cf9c7cedf](https://github.com/StoneCypher/better_git_changelog/commit/70f1c013dcc7120b3565b4ca1ba4691cf9c7cedf)
+
+Author: `John Haugeland <stonecypher@gmail.com>`
+
+  * fix: remove shell-injection risk in tag_to_hash
+  * tag_to_hash interpolated the tag name into a shell command string passed to execSync. Git tag names may legally contain shell metacharacters, so a hostile tag could execute arbitrary commands. It now uses execFileSync with an argument array — no shell, the tag is a single literal argument. (get_commit_message_for_hash has the same pattern but is dead code; it is removed in a later PR in this series.)
 
 
 

--- a/CHANGELOG.long.md
+++ b/CHANGELOG.long.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-51 merges; 9 releases
+52 merges; 9 releases
 
 
 
@@ -14,6 +14,22 @@ Published tags:
 
 <a href="#1__6__5">1.6.5</a>, <a href="#1__6__4">1.6.4</a>, <a href="#1__6__3">1.6.3</a>, <a href="#1__6__2">1.6.2</a>, <a href="#1__6__1">1.6.1</a>, <a href="#1__6__0">1.6.0</a>, <a href="#1__5__0">1.5.0</a>, <a href="#1__4__1">1.4.1</a>, <a href="#1__0__0">1.0.0</a>
 
+
+
+
+
+&nbsp;
+
+&nbsp;
+
+## [Untagged] - May 18, 2026 7:00:47 AM
+
+Commit [e23fbdc457ca77fbfdab56de1fc25c346f1067d8](https://github.com/StoneCypher/better_git_changelog/commit/e23fbdc457ca77fbfdab56de1fc25c346f1067d8)
+
+Author: `John Haugeland <stonecypher@gmail.com>`
+
+  * fix: parse octopus merges with three or more parents
+  * The PEG grammar's MergeRow accepted exactly two parent hashes, so a merge commit with 3+ parents (an octopus merge) failed to parse and crashed parse_rl. MergeRow now accepts one parent followed by one or more additional parents, returning the full list. The regenerated reflog_parser.js is included.
 
 
 

--- a/CHANGELOG.long.md
+++ b/CHANGELOG.long.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-50 merges; 9 releases
+51 merges; 9 releases
 
 
 
@@ -14,6 +14,22 @@ Published tags:
 
 <a href="#1__6__5">1.6.5</a>, <a href="#1__6__4">1.6.4</a>, <a href="#1__6__3">1.6.3</a>, <a href="#1__6__2">1.6.2</a>, <a href="#1__6__1">1.6.1</a>, <a href="#1__6__0">1.6.0</a>, <a href="#1__5__0">1.5.0</a>, <a href="#1__4__1">1.4.1</a>, <a href="#1__0__0">1.0.0</a>
 
+
+
+
+
+&nbsp;
+
+&nbsp;
+
+## [Untagged] - May 18, 2026 12:56:53 AM
+
+Commit [6673f2edea33d8298027baabc0c3403a15ee24a9](https://github.com/StoneCypher/better_git_changelog/commit/6673f2edea33d8298027baabc0c3403a15ee24a9)
+
+Author: `John Haugeland <stonecypher@gmail.com>`
+
+  * fix: tolerate non-semver tags in changelog generation
+  * sem_sort called semver.lt/gt directly, which throw on any tag that is not valid semver; convert_to_md sorts the tag list with it, so a single tag like 'nightly' crashed the whole run. sem_sort now validates first: valid semver tags compare by precedence, non-semver tags compare lexically and sort after, and nothing throws.
 
 
 

--- a/CHANGELOG.long.md
+++ b/CHANGELOG.long.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-54 merges; 9 releases
+55 merges; 9 releases
 
 
 
@@ -14,6 +14,22 @@ Published tags:
 
 <a href="#1__6__5">1.6.5</a>, <a href="#1__6__4">1.6.4</a>, <a href="#1__6__3">1.6.3</a>, <a href="#1__6__2">1.6.2</a>, <a href="#1__6__1">1.6.1</a>, <a href="#1__6__0">1.6.0</a>, <a href="#1__5__0">1.5.0</a>, <a href="#1__4__1">1.4.1</a>, <a href="#1__0__0">1.0.0</a>
 
+
+
+
+
+&nbsp;
+
+&nbsp;
+
+## [Untagged] - May 18, 2026 8:57:57 AM
+
+Commit [472d3b4556fd667deb2f5f4c7fd7b0f278a79092](https://github.com/StoneCypher/better_git_changelog/commit/472d3b4556fd667deb2f5f4c7fd7b0f278a79092)
+
+Author: `John Haugeland <stonecypher@gmail.com>`
+
+  * fix: declare fs instead of leaking it as a global
+  * index.js assigned fs = require('fs') with no const/let/var, which created an implicit global in sloppy mode and would throw a ReferenceError under strict mode. It is now part of the adjacent const declaration.
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-53 merges; 9 releases; Changelogging the last 10 commits; Full changelog at [CHANGELOG.long.md](CHANGELOG.long.md)
+54 merges; 9 releases; Changelogging the last 10 commits; Full changelog at [CHANGELOG.long.md](CHANGELOG.long.md)
 
 
 
@@ -14,6 +14,22 @@ Published tags:
 
 <a href="#1__6__5">1.6.5</a>, <a href="#1__6__4">1.6.4</a>, <a href="#1__6__3">1.6.3</a>, <a href="#1__6__2">1.6.2</a>, <a href="#1__6__1">1.6.1</a>, <a href="#1__6__0">1.6.0</a>, <a href="#1__5__0">1.5.0</a>, <a href="#1__4__1">1.4.1</a>, <a href="#1__0__0">1.0.0</a>
 
+
+
+
+
+&nbsp;
+
+&nbsp;
+
+## [Untagged] - May 18, 2026 7:12:46 AM
+
+Commit [70f1c013dcc7120b3565b4ca1ba4691cf9c7cedf](https://github.com/StoneCypher/better_git_changelog/commit/70f1c013dcc7120b3565b4ca1ba4691cf9c7cedf)
+
+Author: `John Haugeland <stonecypher@gmail.com>`
+
+  * fix: remove shell-injection risk in tag_to_hash
+  * tag_to_hash interpolated the tag name into a shell command string passed to execSync. Git tag names may legally contain shell metacharacters, so a hostile tag could execute arbitrary commands. It now uses execFileSync with an argument array — no shell, the tag is a single literal argument. (get_commit_message_for_hash has the same pattern but is dead code; it is removed in a later PR in this series.)
 
 
 
@@ -164,18 +180,3 @@ Commit [80eecb624d3da4f17fbee01b9eb410042a0c2948](https://github.com/StoneCypher
 Author: `John Haugeland <stonecypher@gmail.com>`
 
   * docs: clarify the Languages section with locale codes and accurate examples
-
-
-
-
-&nbsp;
-
-&nbsp;
-
-## [Untagged] - May 17, 2026 5:09:40 PM
-
-Commit [0f59cbe32c9564de264d5f83b963c01eb3181b3f](https://github.com/StoneCypher/better_git_changelog/commit/0f59cbe32c9564de264d5f83b963c01eb3181b3f)
-
-Author: `John Haugeland <stonecypher@gmail.com>`
-
-  * docs: document CLI internationalization

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-50 merges; 9 releases; Changelogging the last 10 commits; Full changelog at [CHANGELOG.long.md](CHANGELOG.long.md)
+51 merges; 9 releases; Changelogging the last 10 commits; Full changelog at [CHANGELOG.long.md](CHANGELOG.long.md)
 
 
 
@@ -14,6 +14,22 @@ Published tags:
 
 <a href="#1__6__5">1.6.5</a>, <a href="#1__6__4">1.6.4</a>, <a href="#1__6__3">1.6.3</a>, <a href="#1__6__2">1.6.2</a>, <a href="#1__6__1">1.6.1</a>, <a href="#1__6__0">1.6.0</a>, <a href="#1__5__0">1.5.0</a>, <a href="#1__4__1">1.4.1</a>, <a href="#1__0__0">1.0.0</a>
 
+
+
+
+
+&nbsp;
+
+&nbsp;
+
+## [Untagged] - May 18, 2026 12:56:53 AM
+
+Commit [6673f2edea33d8298027baabc0c3403a15ee24a9](https://github.com/StoneCypher/better_git_changelog/commit/6673f2edea33d8298027baabc0c3403a15ee24a9)
+
+Author: `John Haugeland <stonecypher@gmail.com>`
+
+  * fix: tolerate non-semver tags in changelog generation
+  * sem_sort called semver.lt/gt directly, which throw on any tag that is not valid semver; convert_to_md sorts the tag list with it, so a single tag like 'nightly' crashed the whole run. sem_sort now validates first: valid semver tags compare by precedence, non-semver tags compare lexically and sort after, and nothing throws.
 
 
 
@@ -161,18 +177,3 @@ Commit [aa56d69ad100a30c23475144c0a8e01ca66dcaf7](https://github.com/StoneCypher
 Author: `John Haugeland <stonecypher@gmail.com>`
 
   * feat: wire i18n into the CLI
-
-
-
-
-&nbsp;
-
-&nbsp;
-
-## [Untagged] - May 17, 2026 4:48:30 PM
-
-Commit [2f99467d3c1d2b8edd857b3c4299eeb0a91b81f0](https://github.com/StoneCypher/better_git_changelog/commit/2f99467d3c1d2b8edd857b3c4299eeb0a91b81f0)
-
-Author: `John Haugeland <stonecypher@gmail.com>`
-
-  * refactor: tidy the content translator and document its separator limit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-56 merges; 9 releases; Changelogging the last 10 commits; Full changelog at [CHANGELOG.long.md](CHANGELOG.long.md)
+57 merges; 9 releases; Changelogging the last 10 commits; Full changelog at [CHANGELOG.long.md](CHANGELOG.long.md)
 
 
 
@@ -14,6 +14,22 @@ Published tags:
 
 <a href="#1__6__5">1.6.5</a>, <a href="#1__6__4">1.6.4</a>, <a href="#1__6__3">1.6.3</a>, <a href="#1__6__2">1.6.2</a>, <a href="#1__6__1">1.6.1</a>, <a href="#1__6__0">1.6.0</a>, <a href="#1__5__0">1.5.0</a>, <a href="#1__4__1">1.4.1</a>, <a href="#1__0__0">1.0.0</a>
 
+
+
+
+
+&nbsp;
+
+&nbsp;
+
+## [Untagged] - May 18, 2026 9:45:29 AM
+
+Commit [fce0d5b67f5895be5bbb180cfaaed32f885eeb5e](https://github.com/StoneCypher/better_git_changelog/commit/fce0d5b67f5895be5bbb180cfaaed32f885eeb5e)
+
+Author: `John Haugeland <stonecypher@gmail.com>`
+
+  * fix: keep every tag when a commit has more than one
+  * scan() did reflog[idx].tag = tag, so when several tags pointed at the same commit each assignment overwrote the previous and only the last survived. scan() now collects them into an array. default_formatter accepts either a single tag or an array, emitting an anchor per tag and listing them all in the heading, so every tag's index link still resolves.
 
 
 
@@ -164,21 +180,3 @@ Author: `John Haugeland <stonecypher@gmail.com>`
 
   * fix: derive commit URLs from the git remote
   * The changelog formatter hardcoded https://github.com/StoneCypher/jssm as the commit-link base, so every generated changelog linked its commits to an unrelated repository. Commit URLs are now built from the origin remote (parsed from git remote get-url), falling back to a plain unlinked hash when no hosted remote exists. Reported in #2.
-
-
-
-
-&nbsp;
-
-&nbsp;
-
-## [Untagged] - May 17, 2026 9:23:28 PM
-
-Commit [83f760f9eb8fc316b4d16a0650c42354a7b3af58](https://github.com/StoneCypher/better_git_changelog/commit/83f760f9eb8fc316b4d16a0650c42354a7b3af58)
-
-Author: `John Haugeland <stonecypher@gmail.com>`
-
-Merges [64587df, 297f6da]
-
-  * Merge pull request #4 from StoneCypher/feat_26-05-17_cli-i18n
-  * feat: internationalize the CLI with twelve languages

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-52 merges; 9 releases; Changelogging the last 10 commits; Full changelog at [CHANGELOG.long.md](CHANGELOG.long.md)
+53 merges; 9 releases; Changelogging the last 10 commits; Full changelog at [CHANGELOG.long.md](CHANGELOG.long.md)
 
 
 
@@ -14,6 +14,22 @@ Published tags:
 
 <a href="#1__6__5">1.6.5</a>, <a href="#1__6__4">1.6.4</a>, <a href="#1__6__3">1.6.3</a>, <a href="#1__6__2">1.6.2</a>, <a href="#1__6__1">1.6.1</a>, <a href="#1__6__0">1.6.0</a>, <a href="#1__5__0">1.5.0</a>, <a href="#1__4__1">1.4.1</a>, <a href="#1__0__0">1.0.0</a>
 
+
+
+
+
+&nbsp;
+
+&nbsp;
+
+## [Untagged] - May 18, 2026 7:05:59 AM
+
+Commit [6e689419cfad9725f255c8b3a69506bbfdb53557](https://github.com/StoneCypher/better_git_changelog/commit/6e689419cfad9725f255c8b3a69506bbfdb53557)
+
+Author: `John Haugeland <stonecypher@gmail.com>`
+
+  * fix: honor the item_separator option in convert_to_md
+  * convert_to_md resolved separator = item_separator || default_separator but the render loop then called default_separator directly, so a caller-supplied item_separator was silently ignored. The loop now calls the resolved separator.
 
 
 
@@ -163,18 +179,3 @@ Commit [0f59cbe32c9564de264d5f83b963c01eb3181b3f](https://github.com/StoneCypher
 Author: `John Haugeland <stonecypher@gmail.com>`
 
   * docs: document CLI internationalization
-
-
-
-
-&nbsp;
-
-&nbsp;
-
-## [Untagged] - May 17, 2026 5:07:03 PM
-
-Commit [be7171150cdbbdd4c8d125b7cd65203fa5fd6306](https://github.com/StoneCypher/better_git_changelog/commit/be7171150cdbbdd4c8d125b7cd65203fa5fd6306)
-
-Author: `John Haugeland <stonecypher@gmail.com>`
-
-  * fix: stop duplicate CLI error output and honor --ui-lang=fr form

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-54 merges; 9 releases; Changelogging the last 10 commits; Full changelog at [CHANGELOG.long.md](CHANGELOG.long.md)
+55 merges; 9 releases; Changelogging the last 10 commits; Full changelog at [CHANGELOG.long.md](CHANGELOG.long.md)
 
 
 
@@ -14,6 +14,22 @@ Published tags:
 
 <a href="#1__6__5">1.6.5</a>, <a href="#1__6__4">1.6.4</a>, <a href="#1__6__3">1.6.3</a>, <a href="#1__6__2">1.6.2</a>, <a href="#1__6__1">1.6.1</a>, <a href="#1__6__0">1.6.0</a>, <a href="#1__5__0">1.5.0</a>, <a href="#1__4__1">1.4.1</a>, <a href="#1__0__0">1.0.0</a>
 
+
+
+
+
+&nbsp;
+
+&nbsp;
+
+## [Untagged] - May 18, 2026 8:57:57 AM
+
+Commit [472d3b4556fd667deb2f5f4c7fd7b0f278a79092](https://github.com/StoneCypher/better_git_changelog/commit/472d3b4556fd667deb2f5f4c7fd7b0f278a79092)
+
+Author: `John Haugeland <stonecypher@gmail.com>`
+
+  * fix: declare fs instead of leaking it as a global
+  * index.js assigned fs = require('fs') with no const/let/var, which created an implicit global in sloppy mode and would throw a ReferenceError under strict mode. It is now part of the adjacent const declaration.
 
 
 
@@ -165,18 +181,3 @@ Commit [297f6da977a247f7711b36165287511e4f57387c](https://github.com/StoneCypher
 Author: `John Haugeland <stonecypher@gmail.com>`
 
   * change node versions supported in ci/cd
-
-
-
-
-&nbsp;
-
-&nbsp;
-
-## [Untagged] - May 17, 2026 8:59:09 PM
-
-Commit [80eecb624d3da4f17fbee01b9eb410042a0c2948](https://github.com/StoneCypher/better_git_changelog/commit/80eecb624d3da4f17fbee01b9eb410042a0c2948)
-
-Author: `John Haugeland <stonecypher@gmail.com>`
-
-  * docs: clarify the Languages section with locale codes and accurate examples

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-55 merges; 9 releases; Changelogging the last 10 commits; Full changelog at [CHANGELOG.long.md](CHANGELOG.long.md)
+56 merges; 9 releases; Changelogging the last 10 commits; Full changelog at [CHANGELOG.long.md](CHANGELOG.long.md)
 
 
 
@@ -14,6 +14,22 @@ Published tags:
 
 <a href="#1__6__5">1.6.5</a>, <a href="#1__6__4">1.6.4</a>, <a href="#1__6__3">1.6.3</a>, <a href="#1__6__2">1.6.2</a>, <a href="#1__6__1">1.6.1</a>, <a href="#1__6__0">1.6.0</a>, <a href="#1__5__0">1.5.0</a>, <a href="#1__4__1">1.4.1</a>, <a href="#1__0__0">1.0.0</a>
 
+
+
+
+
+&nbsp;
+
+&nbsp;
+
+## [Untagged] - May 18, 2026 9:01:30 AM
+
+Commit [02861f9b9ed1dacccb59c87338dc9f53077e6838](https://github.com/StoneCypher/better_git_changelog/commit/02861f9b9ed1dacccb59c87338dc9f53077e6838)
+
+Author: `John Haugeland <stonecypher@gmail.com>`
+
+  * fix: stop convert_to_md from mutating the caller's tag_list
+  * convert_to_md sorted data.tag_list with Array.prototype.sort, which sorts in place — so it reordered the caller's array (the scan() result) as a side effect. It now sorts a copy.
 
 
 
@@ -166,18 +182,3 @@ Merges [64587df, 297f6da]
 
   * Merge pull request #4 from StoneCypher/feat_26-05-17_cli-i18n
   * feat: internationalize the CLI with twelve languages
-
-
-
-
-&nbsp;
-
-&nbsp;
-
-## [Untagged] - May 17, 2026 9:18:31 PM
-
-Commit [297f6da977a247f7711b36165287511e4f57387c](https://github.com/StoneCypher/better_git_changelog/commit/297f6da977a247f7711b36165287511e4f57387c)
-
-Author: `John Haugeland <stonecypher@gmail.com>`
-
-  * change node versions supported in ci/cd

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,22 @@ Published tags:
 
 &nbsp;
 
+## [Untagged] - May 18, 2026 9:55:25 AM
+
+Commit [c5e90a724cdf065a41b7a08b6db20755d8b7a3f4](https://github.com/StoneCypher/better_git_changelog/commit/c5e90a724cdf065a41b7a08b6db20755d8b7a3f4)
+
+Author: `John Haugeland <stonecypher@gmail.com>`
+
+  * fix: count merge commits, not all commits, in the summary line
+  * The changelog summary rendered data.reflog.length through the 'merges' string, so it reported every commit as a merge (e.g. '441 merges' when 441 was the total entry count). It now counts only entries that actually carry a merge field.
+
+
+
+
+&nbsp;
+
+&nbsp;
+
 ## [Untagged] - May 18, 2026 9:48:07 AM
 
 Commit [1025797c006f88bb9f724467a9c636729cd22254](https://github.com/StoneCypher/better_git_changelog/commit/1025797c006f88bb9f724467a9c636729cd22254)
@@ -162,21 +178,3 @@ Merges [83f760f, 56638f0]
 
   * Merge pull request #5 from StoneCypher/fix_26-05-17_commit-url_2
   * fix: derive commit URLs from the git remote
-
-
-
-
-&nbsp;
-
-&nbsp;
-
-## [Untagged] - May 17, 2026 10:08:44 PM
-
-Commit [56638f08a775de1d034a63250a7b1f382ec80184](https://github.com/StoneCypher/better_git_changelog/commit/56638f08a775de1d034a63250a7b1f382ec80184)
-
-Author: `John Haugeland <stonecypher@gmail.com>`
-
-Merges [1e403b0, 83f760f]
-
-  * Merge origin/main into fix_26-05-17_commit-url_2
-  * PR #4 (CLI i18n) merged to main and also rewrote default_formatter. Conflict resolved: default_formatter is now (item, tr, repo_url) — both translator-aware (from the i18n work) and repo-URL-aware (this branch's issue #2 fix). Also untracks .claude/settings.local.json, a per-machine file committed by mistake, and adds it to .gitignore.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-51 merges; 9 releases; Changelogging the last 10 commits; Full changelog at [CHANGELOG.long.md](CHANGELOG.long.md)
+52 merges; 9 releases; Changelogging the last 10 commits; Full changelog at [CHANGELOG.long.md](CHANGELOG.long.md)
 
 
 
@@ -14,6 +14,22 @@ Published tags:
 
 <a href="#1__6__5">1.6.5</a>, <a href="#1__6__4">1.6.4</a>, <a href="#1__6__3">1.6.3</a>, <a href="#1__6__2">1.6.2</a>, <a href="#1__6__1">1.6.1</a>, <a href="#1__6__0">1.6.0</a>, <a href="#1__5__0">1.5.0</a>, <a href="#1__4__1">1.4.1</a>, <a href="#1__0__0">1.0.0</a>
 
+
+
+
+
+&nbsp;
+
+&nbsp;
+
+## [Untagged] - May 18, 2026 7:00:47 AM
+
+Commit [e23fbdc457ca77fbfdab56de1fc25c346f1067d8](https://github.com/StoneCypher/better_git_changelog/commit/e23fbdc457ca77fbfdab56de1fc25c346f1067d8)
+
+Author: `John Haugeland <stonecypher@gmail.com>`
+
+  * fix: parse octopus merges with three or more parents
+  * The PEG grammar's MergeRow accepted exactly two parent hashes, so a merge commit with 3+ parents (an octopus merge) failed to parse and crashed parse_rl. MergeRow now accepts one parent followed by one or more additional parents, returning the full list. The regenerated reflog_parser.js is included.
 
 
 
@@ -162,18 +178,3 @@ Commit [be7171150cdbbdd4c8d125b7cd65203fa5fd6306](https://github.com/StoneCypher
 Author: `John Haugeland <stonecypher@gmail.com>`
 
   * fix: stop duplicate CLI error output and honor --ui-lang=fr form
-
-
-
-
-&nbsp;
-
-&nbsp;
-
-## [Untagged] - May 17, 2026 4:51:07 PM
-
-Commit [aa56d69ad100a30c23475144c0a8e01ca66dcaf7](https://github.com/StoneCypher/better_git_changelog/commit/aa56d69ad100a30c23475144c0a8e01ca66dcaf7)
-
-Author: `John Haugeland <stonecypher@gmail.com>`
-
-  * feat: wire i18n into the CLI

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-57 merges; 9 releases; Changelogging the last 10 commits; Full changelog at [CHANGELOG.long.md](CHANGELOG.long.md)
+4 merges; 9 releases; Changelogging the last 10 commits; Full changelog at [CHANGELOG.long.md](CHANGELOG.long.md)
 
 
 
@@ -14,6 +14,22 @@ Published tags:
 
 <a href="#1__6__5">1.6.5</a>, <a href="#1__6__4">1.6.4</a>, <a href="#1__6__3">1.6.3</a>, <a href="#1__6__2">1.6.2</a>, <a href="#1__6__1">1.6.1</a>, <a href="#1__6__0">1.6.0</a>, <a href="#1__5__0">1.5.0</a>, <a href="#1__4__1">1.4.1</a>, <a href="#1__0__0">1.0.0</a>
 
+
+
+
+
+&nbsp;
+
+&nbsp;
+
+## [Untagged] - May 18, 2026 9:48:07 AM
+
+Commit [1025797c006f88bb9f724467a9c636729cd22254](https://github.com/StoneCypher/better_git_changelog/commit/1025797c006f88bb9f724467a9c636729cd22254)
+
+Author: `John Haugeland <stonecypher@gmail.com>`
+
+  * refactor: remove dead get_commit_message_for_hash
+  * get_commit_message_for_hash was never called and never exported, so it was unreachable code — and it carried the same string-interpolated execSync injection pattern that was fixed in tag_to_hash. Removing it eliminates both. No test accompanies this change because there was nothing reachable to test; the existing suite still passes, confirming nothing depended on it.
 
 
 
@@ -164,19 +180,3 @@ Merges [1e403b0, 83f760f]
 
   * Merge origin/main into fix_26-05-17_commit-url_2
   * PR #4 (CLI i18n) merged to main and also rewrote default_formatter. Conflict resolved: default_formatter is now (item, tr, repo_url) — both translator-aware (from the i18n work) and repo-URL-aware (this branch's issue #2 fix). Also untracks .claude/settings.local.json, a per-machine file committed by mistake, and adds it to .gitignore.
-
-
-
-
-&nbsp;
-
-&nbsp;
-
-## [Untagged] - May 17, 2026 9:42:21 PM
-
-Commit [1e403b0c35bd75c6b1cc09ec42a2acea7ccd1cbb](https://github.com/StoneCypher/better_git_changelog/commit/1e403b0c35bd75c6b1cc09ec42a2acea7ccd1cbb)
-
-Author: `John Haugeland <stonecypher@gmail.com>`
-
-  * fix: derive commit URLs from the git remote
-  * The changelog formatter hardcoded https://github.com/StoneCypher/jssm as the commit-link base, so every generated changelog linked its commits to an unrelated repository. Commit URLs are now built from the origin remote (parsed from git remote get-url), falling back to a plain unlinked hash when no hosted remote exists. Reported in #2.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "better_git_changelog",
-  "version": "1.6.8",
+  "version": "1.6.9",
   "description": "Make a changelog from git commits, tags, and releases",
   "main": "src/js/index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "better_git_changelog",
-  "version": "1.6.14",
+  "version": "1.6.15",
   "description": "Make a changelog from git commits, tags, and releases",
   "main": "src/js/index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "better_git_changelog",
-  "version": "1.6.7",
+  "version": "1.6.8",
   "description": "Make a changelog from git commits, tags, and releases",
   "main": "src/js/index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "better_git_changelog",
-  "version": "1.6.11",
+  "version": "1.6.12",
   "description": "Make a changelog from git commits, tags, and releases",
   "main": "src/js/index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "better_git_changelog",
-  "version": "1.6.10",
+  "version": "1.6.11",
   "description": "Make a changelog from git commits, tags, and releases",
   "main": "src/js/index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "better_git_changelog",
-  "version": "1.6.12",
+  "version": "1.6.13",
   "description": "Make a changelog from git commits, tags, and releases",
   "main": "src/js/index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "better_git_changelog",
-  "version": "1.6.6",
+  "version": "1.6.7",
   "description": "Make a changelog from git commits, tags, and releases",
   "main": "src/js/index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "better_git_changelog",
-  "version": "1.6.13",
+  "version": "1.6.14",
   "description": "Make a changelog from git commits, tags, and releases",
   "main": "src/js/index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "better_git_changelog",
-  "version": "1.6.9",
+  "version": "1.6.10",
   "description": "Make a changelog from git commits, tags, and releases",
   "main": "src/js/index.js",
   "bin": {

--- a/src/js/cli.js
+++ b/src/js/cli.js
@@ -3,7 +3,20 @@
 const api  = require('./index.js');
 const i18n = require('./i18n.js');
 
-const { program } = require('commander');
+const { program, InvalidArgumentError } = require('commander');
+
+
+
+// Coerce and validate the -S/--short-length value: a positive integer.
+// An invalid value raises InvalidArgumentError so commander rejects the
+// run, instead of silently producing an empty changelog from slice(0, NaN).
+function parse_short_length(value) {
+  const n = Number(value);
+  if (!Number.isInteger(n) || n < 1) {
+    throw new InvalidArgumentError('must be a positive integer.');
+  }
+  return n;
+}
 
 
 
@@ -32,7 +45,7 @@ program
   .helpOption('-h, --help', ut('ui', 'optHelp'))
   .option('-l, --long-form',             ut('ui', 'optLongForm'))
   .option('-s, --short-form',            ut('ui', 'optShortForm'))
-  .option('-S, --short-length <count>',  ut('ui', 'optShortLength'))
+  .option('-S, --short-length <count>',  ut('ui', 'optShortLength'), parse_short_length)
   .option('-b, --both-forms [filename]', ut('ui', 'optBothForms'))
   .option('-f, --filename <filename>',   ut('ui', 'optFilename'), 'CHANGELOG.md')
   .option('-u, --ui-lang <code>',        ut('ui', 'optUiLang'))

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -73,9 +73,21 @@ function get_tag_list() {
 
 
 
+/**
+ * Resolve a tag name to the hash of the commit it points at.
+ *
+ * Spawned shell-free with execFileSync, so a tag name containing shell
+ * metacharacters cannot be reinterpreted by a shell.
+ *
+ * @param tag  A git tag name.
+ * @returns The commit hash the tag resolves to.
+ *
+ * @example
+ *   tag_to_hash('1.6.8');   // 'a1b2c3d4...'
+ */
 function tag_to_hash(tag) {
 
-  return cp.execSync(`git rev-list -n 1 ${tag}`)
+  return cp.execFileSync('git', [ 'rev-list', '-n', '1', tag ])
     .toString()
     .trim();
 

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -432,7 +432,7 @@ function convert_to_md({ target, data, item_formatter, item_separator, preface, 
 
   let md = prefix;
 
-  const merge_ct = data.reflog.length,
+  const merge_ct = data.reflog.filter(r => r.merge).length,
         rel_ct   = data.tag_list.length,
         notes    = [];
 

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -445,7 +445,7 @@ function convert_to_md({ target, data, item_formatter, item_separator, preface, 
   const urefs = is_short ? data.reflog.slice(0, use_sl) : data.reflog;
 
   urefs.forEach( (rli) => {
-    md += default_separator(rli);
+    md += separator(rli);
     md += formatter(rli, tr, data.repo_url);
   } );
 

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -450,7 +450,7 @@ function convert_to_md({ target, data, item_formatter, item_separator, preface, 
   md += notes.join('; ');
 
   if (data.tag_list) {
-    const sorted = data.tag_list.sort(sem_sort).reverse();
+    const sorted = [...data.tag_list].sort(sem_sort).reverse();
     md += '\n\n\n\n&nbsp;\n\n&nbsp;\n\n' + t('changelog', 'publishedTags') + '\n\n' + sorted.map(to_link).join(', ') + '\n';
   }
 

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -241,17 +241,6 @@ function scan_all() {
 
 
 
-function get_commit_message_for_hash(hash) {
-
-  return cp.execSync(`git log -n 1 --pretty=format:%s ${hash}`)
-    .toString()
-    .trim();
-
-}
-
-
-
-
 
 /**
  * Scan the current repository: gather its tags, reflog, and remote URL.

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -277,7 +277,7 @@ function scan() {
       not_found.push(tag);
     } else {
       found.push(tag);
-      reflog[idx].tag = tag;
+      ( reflog[idx].tag || (reflog[idx].tag = []) ).push(tag);
     }
 
   } );
@@ -331,7 +331,8 @@ function slug(text) {
  * Render one parsed reflog entry as a Markdown changelog section.
  *
  * @param item      A reflog entry: `commit_hash` and `commit_text`, plus the
- *                  optional `tag`, `date`, `author`, and `merge` fields.
+ *                  optional `tag` (a tag name, or an array of tag names when a
+ *                  commit carries several), `date`, `author`, and `merge`.
  * @param tr        A translator from i18n.make_translator; defaults to English.
  * @param repo_url  The repository's web base URL. When given, the commit hash
  *                  is linked to `<repo_url>/commit/<hash>`; when absent, the
@@ -346,16 +347,20 @@ function default_formatter(item, tr, repo_url) {
   const t = tr.t;
   const d = item.date ? new Date(item.date) : null;
 
+  const tags = item.tag
+    ? (Array.isArray(item.tag) ? item.tag : [item.tag])
+    : [];
+
   return `${
 
-    item.tag
-      ? `<a name="${slug(item.tag)}" />\n\n`
+    tags.length
+      ? tags.map(tg => `<a name="${slug(tg)}" />`).join('\n\n') + '\n\n'
       : ''
 
   }##${
 
-    item.tag
-      ? ` [${item.tag}]`
+    tags.length
+      ? tags.map(tg => ` [${tg}]`).join('')
       : ` [${t('changelog', 'untagged')}]`
 
   }${

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -1,5 +1,5 @@
 
-const cp = require('child_process');
+const cp = require('child_process'),
       fs = require('fs');
 
 const sv = require('semver');

--- a/src/js/reflog_parser.js
+++ b/src/js/reflog_parser.js
@@ -153,7 +153,9 @@ function peg$parse(input, options) {
       peg$c9 = peg$literalExpectation("Merge: ", false),
       peg$c10 = " ",
       peg$c11 = peg$literalExpectation(" ", false),
-      peg$c12 = function(hash1, hash2) { return [hash1, hash2]; },
+      peg$c12 = function(first, rest) {
+          return [first, ...rest.map(r => r[1])];
+        },
       peg$c13 = "Author: ",
       peg$c14 = peg$literalExpectation("Author: ", false),
       peg$c15 = /^[^\n]/,
@@ -685,7 +687,7 @@ function peg$parse(input, options) {
   }
 
   function peg$parseMergeRow() {
-    var s0, s1, s2, s3, s4, s5;
+    var s0, s1, s2, s3, s4, s5, s6;
 
     s0 = peg$currPos;
     if (input.substr(peg$currPos, 7) === peg$c8) {
@@ -698,31 +700,68 @@ function peg$parse(input, options) {
     if (s1 !== peg$FAILED) {
       s2 = peg$parseShortHash();
       if (s2 !== peg$FAILED) {
+        s3 = [];
+        s4 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 32) {
-          s3 = peg$c10;
+          s5 = peg$c10;
           peg$currPos++;
         } else {
-          s3 = peg$FAILED;
+          s5 = peg$FAILED;
           if (peg$silentFails === 0) { peg$fail(peg$c11); }
         }
-        if (s3 !== peg$FAILED) {
-          s4 = peg$parseShortHash();
-          if (s4 !== peg$FAILED) {
-            if (input.charCodeAt(peg$currPos) === 10) {
-              s5 = peg$c5;
+        if (s5 !== peg$FAILED) {
+          s6 = peg$parseShortHash();
+          if (s6 !== peg$FAILED) {
+            s5 = [s5, s6];
+            s4 = s5;
+          } else {
+            peg$currPos = s4;
+            s4 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s4;
+          s4 = peg$FAILED;
+        }
+        if (s4 !== peg$FAILED) {
+          while (s4 !== peg$FAILED) {
+            s3.push(s4);
+            s4 = peg$currPos;
+            if (input.charCodeAt(peg$currPos) === 32) {
+              s5 = peg$c10;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c6); }
+              if (peg$silentFails === 0) { peg$fail(peg$c11); }
             }
             if (s5 !== peg$FAILED) {
-              peg$savedPos = s0;
-              s1 = peg$c12(s2, s4);
-              s0 = s1;
+              s6 = peg$parseShortHash();
+              if (s6 !== peg$FAILED) {
+                s5 = [s5, s6];
+                s4 = s5;
+              } else {
+                peg$currPos = s4;
+                s4 = peg$FAILED;
+              }
             } else {
-              peg$currPos = s0;
-              s0 = peg$FAILED;
+              peg$currPos = s4;
+              s4 = peg$FAILED;
             }
+          }
+        } else {
+          s3 = peg$FAILED;
+        }
+        if (s3 !== peg$FAILED) {
+          if (input.charCodeAt(peg$currPos) === 10) {
+            s4 = peg$c5;
+            peg$currPos++;
+          } else {
+            s4 = peg$FAILED;
+            if (peg$silentFails === 0) { peg$fail(peg$c6); }
+          }
+          if (s4 !== peg$FAILED) {
+            peg$savedPos = s0;
+            s1 = peg$c12(s2, s3);
+            s0 = s1;
           } else {
             peg$currPos = s0;
             s0 = peg$FAILED;

--- a/src/js/test/formatter.test.js
+++ b/src/js/test/formatter.test.js
@@ -105,11 +105,25 @@ test('convert_to_md emits the default preface, counts, and tag index', () => {
   const md = convert_to_md({ data: sampleData() });
 
   assert.ok(md.startsWith('# Changelog'));
-  assert.match(md, /2 merges/);
   assert.match(md, /2 releases/);
   assert.match(md, /Published tags:/);
   assert.match(md, /  \* one/);
   assert.match(md, /  \* two/);
+});
+
+test('convert_to_md counts merge commits, not all commits, in the summary', () => {
+  const data = {
+    reflog: [
+      { commit_hash: 'a', commit_text: ['x'], merge: ['p1', 'p2'] },
+      { commit_hash: 'b', commit_text: ['y'] },
+      { commit_hash: 'c', commit_text: ['z'], merge: ['p3', 'p4'] },
+    ],
+    tag_list:   [],
+    tag_hashes: new Map(),
+  };
+  const md = convert_to_md({ data });
+  assert.match(md, /2 merges/);          // 2 merge commits among 3 entries
+  assert.doesNotMatch(md, /3 merges/);
 });
 
 test('slug preserves non-ASCII letters and digits', () => {
@@ -131,5 +145,5 @@ test('convert_to_md renders boilerplate in the changelog locale', () => {
   const md = convert_to_md({ data: sampleData(), translator: i18n.make_translator('es') });
   assert.ok(md.startsWith('# Registro de cambios'));
   assert.match(md, /Etiquetas publicadas:/);
-  assert.match(md, /2 fusiones/);
+  assert.match(md, /2 versiones/);
 });

--- a/src/js/test/formatter.test.js
+++ b/src/js/test/formatter.test.js
@@ -83,6 +83,13 @@ test('convert_to_md does not mutate the caller\'s tag_list', () => {
   assert.deepStrictEqual(data.tag_list, before);
 });
 
+test('default_formatter renders every tag on a multiply-tagged commit', () => {
+  const md = default_formatter({ tag: ['1.0.0', 'stable'], commit_hash: 'abc', commit_text: ['m'] });
+  assert.match(md, /## \[1\.0\.0\] \[stable\]/);
+  assert.match(md, /<a name="1__0__0" \/>/);
+  assert.match(md, /<a name="stable" \/>/);
+});
+
 function sampleData() {
   return {
     reflog: [

--- a/src/js/test/formatter.test.js
+++ b/src/js/test/formatter.test.js
@@ -71,6 +71,11 @@ test('convert_to_md tolerates non-semver tags without throwing', () => {
   assert.match(md, /2\.0\.0/);
 });
 
+test('convert_to_md honors a custom item_separator', () => {
+  const md = convert_to_md({ data: sampleData(), item_separator: () => '\n===CUSTOMSEP===\n' });
+  assert.match(md, /===CUSTOMSEP===/);
+});
+
 function sampleData() {
   return {
     reflog: [

--- a/src/js/test/formatter.test.js
+++ b/src/js/test/formatter.test.js
@@ -76,6 +76,13 @@ test('convert_to_md honors a custom item_separator', () => {
   assert.match(md, /===CUSTOMSEP===/);
 });
 
+test('convert_to_md does not mutate the caller\'s tag_list', () => {
+  const data   = { reflog: [], tag_list: ['1.0.0', '3.0.0', '2.0.0'], tag_hashes: new Map() };
+  const before = [...data.tag_list];
+  convert_to_md({ data });
+  assert.deepStrictEqual(data.tag_list, before);
+});
+
 function sampleData() {
   return {
     reflog: [

--- a/src/js/test/globals.test.js
+++ b/src/js/test/globals.test.js
@@ -1,0 +1,11 @@
+const test   = require('node:test');
+const assert = require('node:assert');
+
+test('loading index.js does not leak an `fs` global', () => {
+  // `fs` was assigned without a declarator, which created a global in
+  // sloppy mode. Loading the module must not touch global scope.
+  delete global.fs;
+  delete require.cache[require.resolve('../index.js')];
+  require('../index.js');
+  assert.strictEqual(global.fs, undefined);
+});

--- a/src/js/test/integration.test.js
+++ b/src/js/test/integration.test.js
@@ -76,6 +76,13 @@ test('write_short_md writes a truncated changelog file', () => {
   }
 });
 
+test('the CLI rejects a non-numeric --short-length instead of emptying the changelog', () => {
+  const child = require('node:child_process');
+  const cli   = path.join(__dirname, '..', 'cli.js');
+  const r     = child.spawnSync('node', [cli, '-S', 'abc'], { encoding: 'utf8' });
+  assert.notStrictEqual(r.status, 0);   // exits non-zero rather than silently succeeding
+});
+
 test('convert_to_json writes parseable JSON', () => {
   const target = tempPath('json', 'json');
   try {

--- a/src/js/test/integration.test.js
+++ b/src/js/test/integration.test.js
@@ -40,6 +40,13 @@ test('tag_to_hash resolves a real tag to a 40-char hash, when tags exist', () =>
   assert.match(api.tag_to_hash(tags[0]), /^[a-fA-F0-9]{40}$/);
 });
 
+test('tag_to_hash does not let a tag name reach the shell', () => {
+  // With execFileSync the whole string is a single git argument (an unknown
+  // ref), so git fails and execFileSync throws. The old shell form would have
+  // run the trailing `; echo ...` and returned its output instead of throwing.
+  assert.throws(() => api.tag_to_hash('no-such-ref; echo shell-injection'));
+});
+
 test('tags_to_hashes maps every distinct tag to a hash', () => {
   const tags   = api.get_tag_list();
   const hashes = api.tags_to_hashes(tags);

--- a/src/js/test/parser.test.js
+++ b/src/js/test/parser.test.js
@@ -44,3 +44,18 @@ test('exactly the fixture\'s 92 merge commits carry a merge array', () => {
   const merges = reflog.filter(e => e.merge !== undefined);
   assert.strictEqual(merges.length, 92);
 });
+
+test('parse_rl handles an octopus merge (three or more parents)', () => {
+  const octopus =
+    'commit 1111111111111111111111111111111111111111\n' +
+    'Merge: aaaaaaa bbbbbbb ccccccc\n' +
+    'Author: A <a@example.com>\n' +
+    'Date:   Sun May 18 12:00:00 2026 -0700\n' +
+    '\n' +
+    '    octopus merge\n' +
+    '\n';
+  let parsed;
+  assert.doesNotThrow(() => { parsed = parse_rl(octopus); });
+  assert.strictEqual(parsed.length, 1);
+  assert.deepStrictEqual(parsed[0].merge, ['aaaaaaa', 'bbbbbbb', 'ccccccc']);
+});

--- a/src/peg/reflog_parser.peg
+++ b/src/peg/reflog_parser.peg
@@ -16,7 +16,9 @@ CommitRow
   = 'commit ' hash:Hash '\n' { return hash; }
 
 MergeRow
-  = 'Merge: ' hash1:ShortHash ' ' hash2:ShortHash '\n' { return [hash1, hash2]; }
+  = 'Merge: ' first:ShortHash rest:(' ' ShortHash)+ '\n' {
+    return [first, ...rest.map(r => r[1])];
+  }
 
 AuthorRow
   = 'Author: ' author:[^\n]* '\n' { return author.join(''); }


### PR DESCRIPTION
## Summary

Bug fixes 2-10 were merged via PRs #7-#15, but those PRs were *stacked* — each targeted the previous fix branch rather than `main` — so only PR #6 (bug 1) reached `main`. The other nine fixes pooled inside the fix-branch chain.

`fix_26-05-18_short-length` is the pristine linear branch carrying all ten fixes in order. `main` already has bug 1, so this PR delivers exactly the remaining nine:

- Bug 2 — parse octopus merges (3+ parents)
- Bug 3 — honor the `item_separator` option
- Bug 4 — close the `tag_to_hash` shell-injection
- Bug 5 — declare `fs` instead of leaking a global
- Bug 6 — stop `convert_to_md` mutating the caller's `tag_list`
- Bug 7 — keep every tag on a multiply-tagged commit
- Bug 8 — remove dead `get_commit_message_for_hash`
- Bug 9 — count merge commits, not all commits
- Bug 10 — reject a non-numeric `--short-length`

## Test plan

- [ ] `npm test` — 58 pass
- [ ] `npm run build` — succeeds

Recovery PR for the stacked-PR mishap. After this merges, fix branches `fix_26-05-18_octopus-merge` through `fix_26-05-18_short-length` (and `refactor_26-05-18_remove-dead-code`) are fully redundant and can be deleted.