### PR TITLE
ci: publish to npm via OIDC trusted publishing

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -36,9 +36,9 @@ jobs:
     runs-on: ${{matrix.os}}
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
     - name: npm install, build, and test
@@ -52,15 +52,19 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
 
+    permissions:
+      id-token: write     # required for npm trusted publishing (OIDC)
+      contents: write     # the job pushes tags and creates a release
+
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Export tag to envvars
       run: |
         export TAG=$(awk -F'"' '/"version": ".+"/{ print $4; exit; }' package.json)
         echo "TAG=$TAG" >> $GITHUB_ENV
     - name: Use Node.js 18.x
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v4
       with:
         node-version: 18.x
         registry-url: https://registry.npmjs.org/
@@ -77,8 +81,8 @@ jobs:
         release_name: ${{ env.TAG }}
         body_path: CHANGELOG.md
 
+    - name: Upgrade npm to a version that supports trusted publishing
+      run: npm install -g npm@latest
+
     - name: Publish to npm
-      run: |
-        npm publish
-      env:
-        NODE_AUTH_TOKEN: ${{ secrets.GH_ACTIONS_PUBLISH_TOKEN }}
+      run: npm publish


### PR DESCRIPTION
## Summary

The `release` job published with a long-lived `NODE_AUTH_TOKEN` (`GH_ACTIONS_PUBLISH_TOKEN`), which no longer works under npm's current auth model. This switches it to **trusted publishing** (OIDC):

- Adds `permissions: id-token: write` (and `contents: write` for the tag push / release creation) to the `release` job — this lets npm authenticate via GitHub's OIDC.
- Adds an "Upgrade npm" step so npm is new enough (>= 11.5.1) to support trusted publishing.
- Removes the `NODE_AUTH_TOKEN` env from the publish step — `npm publish` now authenticates itself and gets build provenance for free.
- Bumps `actions/checkout` (v1 and v2) and `actions/setup-node` (v1) to v4.

## Before merging — required external step

The package's **trusted publisher must be registered on npmjs.com first** (npmjs.com → `better_git_changelog` → Settings → Trusted Publisher → GitHub Actions; org `StoneCypher`, repo `better_git_changelog`, workflow `node.js.yml`). If this PR merges before that is done, the next release's publish step fails.

After the first successful OIDC publish, delete the now-unused `GH_ACTIONS_PUBLISH_TOKEN` repo secret.

## Not changed

`actions/create-release@v1` (archived) and the `release` job's Node 18 are left as-is — out of scope for this change; worth a follow-up.

## Test plan

- [ ] Register the trusted publisher on npmjs.com
- [ ] Merge; confirm the next release's `npm publish` succeeds via OIDC with no token