### PR TITLE
ci: skip release and publish when the version is unchanged

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -63,6 +63,17 @@ jobs:
       run: |
         export TAG=$(awk -F'"' '/"version": ".+"/{ print $4; exit; }' package.json)
         echo "TAG=$TAG" >> $GITHUB_ENV
+
+    - name: Determine whether this version is already released
+      id: release_state
+      run: |
+        if git ls-remote --exit-code origin "refs/tags/$TAG" >/dev/null 2>&1; then
+          echo "Version $TAG is already released; release and publish will be skipped."
+          echo "new_version=false" >> "$GITHUB_OUTPUT"
+        else
+          echo "new_version=true" >> "$GITHUB_OUTPUT"
+        fi
+
     - name: Use Node.js 18.x
       uses: actions/setup-node@v4
       with:
@@ -70,9 +81,11 @@ jobs:
         registry-url: https://registry.npmjs.org/
 
     - name: Push tags
+      if: steps.release_state.outputs.new_version == 'true'
       run: git push origin --tags
 
     - name: Create the release
+      if: steps.release_state.outputs.new_version == 'true'
       uses: actions/create-release@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -82,7 +95,9 @@ jobs:
         body_path: CHANGELOG.md
 
     - name: Upgrade npm to a version that supports trusted publishing
+      if: steps.release_state.outputs.new_version == 'true'
       run: npm install -g npm@latest
 
     - name: Publish to npm
+      if: steps.release_state.outputs.new_version == 'true'
       run: npm publish


### PR DESCRIPTION
## Summary

The `release` job runs on every owner push to `main` and *unconditionally* creates a GitHub release for `package.json`'s version. Any push that doesn't bump the version — a CI-only change, a docs tweak, etc. — re-runs it for an already-released version:

```
Run actions/create-release@v1
Error: Validation Failed: {"resource":"Release","code":"already_exists","field":"tag_name"}
```

(`npm publish` would reject the duplicate version for the same reason.)

This adds a step that checks whether the version's tag already exists on `origin`. "Push tags", "Create the release", "Upgrade npm", and "Publish to npm" now run **only when the version is new**. A no-bump push to `main` makes those steps skip cleanly instead of failing the job.

## Test plan

- [ ] Merge; confirm the `release` job for this (unchanged-version) merge skips the release/publish steps and goes green
- [ ] On the next version-bumping merge, confirm release + publish still run

Fixes the merge failures caused by PR #17 (a CI change with no version bump).