### PR TITLE
refactor: extract testable CLI logic into cli_core.js for coverage

### DIFF
--- a/CHANGELOG.long.md
+++ b/CHANGELOG.long.md
@@ -22,6 +22,21 @@ Published tags:
 
 &nbsp;
 
+## [Untagged] - May 18, 2026 3:41:17 PM
+
+Commit [80318800063d3480e736f1448c3e5cd89424d764](https://github.com/StoneCypher/better_git_changelog/commit/80318800063d3480e736f1448c3e5cd89424d764)
+
+Author: `John Haugeland <stonecypher@gmail.com>`
+
+  * tag under node 24
+
+
+
+
+&nbsp;
+
+&nbsp;
+
 ## [Untagged] - May 18, 2026 2:22:25 PM
 
 Commit [5ae8f70f0dca34e29de777379e07db06ad3b884d](https://github.com/StoneCypher/better_git_changelog/commit/5ae8f70f0dca34e29de777379e07db06ad3b884d)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,21 @@ Published tags:
 
 &nbsp;
 
+## [Untagged] - May 18, 2026 3:41:17 PM
+
+Commit [80318800063d3480e736f1448c3e5cd89424d764](https://github.com/StoneCypher/better_git_changelog/commit/80318800063d3480e736f1448c3e5cd89424d764)
+
+Author: `John Haugeland <stonecypher@gmail.com>`
+
+  * tag under node 24
+
+
+
+
+&nbsp;
+
+&nbsp;
+
 ## [Untagged] - May 18, 2026 2:22:25 PM
 
 Commit [5ae8f70f0dca34e29de777379e07db06ad3b884d](https://github.com/StoneCypher/better_git_changelog/commit/5ae8f70f0dca34e29de777379e07db06ad3b884d)
@@ -170,19 +185,3 @@ Author: `John Haugeland <stonecypher@gmail.com>`
 
   * refactor: remove dead get_commit_message_for_hash
   * get_commit_message_for_hash was never called and never exported, so it was unreachable code — and it carried the same string-interpolated execSync injection pattern that was fixed in tag_to_hash. Removing it eliminates both. No test accompanies this change because there was nothing reachable to test; the existing suite still passes, confirming nothing depended on it.
-
-
-
-
-&nbsp;
-
-&nbsp;
-
-## [Untagged] - May 18, 2026 9:45:29 AM
-
-Commit [fce0d5b67f5895be5bbb180cfaaed32f885eeb5e](https://github.com/StoneCypher/better_git_changelog/commit/fce0d5b67f5895be5bbb180cfaaed32f885eeb5e)
-
-Author: `John Haugeland <stonecypher@gmail.com>`
-
-  * fix: keep every tag when a commit has more than one
-  * scan() did reflog[idx].tag = tag, so when several tags pointed at the same commit each assignment overwrote the previous and only the last survived. scan() now collects them into an array. default_formatter accepts either a single tag or an array, emitting an anchor per tag and listing them all in the heading, so every tag's index link still resolves.

--- a/src/js/cli.js
+++ b/src/js/cli.js
@@ -3,32 +3,11 @@
 const api  = require('./index.js');
 const i18n = require('./i18n.js');
 
-const { program, InvalidArgumentError } = require('commander');
+const { program } = require('commander');
+
+const { prescan_ui_lang, parse_short_length, resolve_output_plan } = require('./cli_core.js');
 
 
-
-// Coerce and validate the -S/--short-length value: a positive integer.
-// An invalid value raises InvalidArgumentError so commander rejects the
-// run, instead of silently producing an empty changelog from slice(0, NaN).
-function parse_short_length(value) {
-  const n = Number(value);
-  if (!Number.isInteger(n) || n < 1) {
-    throw new InvalidArgumentError('must be a positive integer.');
-  }
-  return n;
-}
-
-
-
-function prescan_ui_lang(argv) {
-  for (const a of argv) {
-    if (a.startsWith('--ui-lang=')) { return a.slice('--ui-lang='.length); }
-  }
-  const i = argv.findIndex(a => a === '--ui-lang' || a === '-u');
-  return (i !== -1 && argv[i + 1] && !argv[i + 1].startsWith('-'))
-    ? argv[i + 1]
-    : null;
-}
 
 const uiLocale = i18n.detect_ui_locale(prescan_ui_lang(process.argv), process.env);
 const uiTr     = i18n.make_translator(uiLocale);
@@ -95,19 +74,7 @@ if (clTr.unsupported) {
 
 
 
-let long  = false,
-    short = false,
-    fn    = opts.filename,
-    fn2   = opts.bothForms,
-    ulen  = opts.shortLength ?? 10;
-
-if (fn2 === true) { fn2 = 'CHANGELOG.long.md'; }
-
-if (opts.longForm)  { long  = true; }
-if (opts.shortForm) { short = true; }
-if (opts.bothForms) { short = true; long = true; }
-
-if ( (!(long)) && (!(short)) ) { long = true; }
+const { long, short, fn, fn2, ulen } = resolve_output_plan(opts);
 
 
 

--- a/src/js/cli_core.js
+++ b/src/js/cli_core.js
@@ -1,0 +1,105 @@
+'use strict';
+
+const { InvalidArgumentError } = require('commander');
+
+
+
+/**
+ * Find the requested UI language in raw argv, before commander parses.
+ *
+ * The help text and option descriptions are built eagerly, so the UI locale
+ * has to be known before `program.parse()` runs. This scans the raw argument
+ * vector for `--ui-lang=<code>`, then for the space-separated `--ui-lang`/`-u`
+ * forms, guarding against reading a following flag as the value.
+ *
+ * @param argv  The process argument vector (e.g. `process.argv`).
+ * @returns The requested language code, or `null` when none was given.
+ *
+ * @example
+ *   prescan_ui_lang(['node', 'cli.js', '--ui-lang=de']);  // 'de'
+ *   prescan_ui_lang(['node', 'cli.js', '-u', 'fr']);      // 'fr'
+ *   prescan_ui_lang(['node', 'cli.js', '-l']);            // null
+ */
+function prescan_ui_lang(argv) {
+
+  for (const a of argv) {
+    if (a.startsWith('--ui-lang=')) { return a.slice('--ui-lang='.length); }
+  }
+
+  const i = argv.findIndex(a => a === '--ui-lang' || a === '-u');
+
+  return (i !== -1 && argv[i + 1] && !argv[i + 1].startsWith('-'))
+    ? argv[i + 1]
+    : null;
+
+}
+
+
+
+/**
+ * Coerce and validate the `-S`/`--short-length` option value.
+ *
+ * @param value  The raw option string from commander.
+ * @returns The value as a positive integer.
+ * @throws {InvalidArgumentError} When the value is not a positive integer, so
+ *         commander rejects the run rather than silently producing an empty
+ *         changelog from `slice(0, NaN)`.
+ *
+ * @example
+ *   parse_short_length('25');   // 25
+ *   parse_short_length('abc');  // throws InvalidArgumentError
+ */
+function parse_short_length(value) {
+
+  const n = Number(value);
+
+  if (!Number.isInteger(n) || n < 1) {
+    throw new InvalidArgumentError('must be a positive integer.');
+  }
+
+  return n;
+
+}
+
+
+
+/**
+ * Decide which changelog forms to write from the parsed options.
+ *
+ * `-l`/`-s` select the long or short form, `-b` selects both, and with no
+ * form flag the long form is the default.
+ *
+ * @param opts  Commander's parsed options: `longForm`, `shortForm`,
+ *              `bothForms`, `filename`, `shortLength`.
+ * @returns `{ long, short, fn, fn2, ulen }` — whether to write each form, the
+ *          main output filename, the long-form filename (`bothForms` as given,
+ *          or the default when it was passed as a bare flag), and the
+ *          short-form entry count.
+ *
+ * @example
+ *   resolve_output_plan({ filename: 'CHANGELOG.md' });
+ *   // { long: true, short: false, fn: 'CHANGELOG.md', fn2: undefined, ulen: 10 }
+ *
+ *   resolve_output_plan({ bothForms: true, filename: 'CHANGELOG.md' });
+ *   // { long: true, short: true, fn: 'CHANGELOG.md', fn2: 'CHANGELOG.long.md', ulen: 10 }
+ */
+function resolve_output_plan(opts) {
+
+  let long  = Boolean(opts.longForm  || opts.bothForms),
+      short = Boolean(opts.shortForm || opts.bothForms);
+
+  if ((!long) && (!short)) { long = true; }
+
+  return {
+    long,
+    short,
+    fn:   opts.filename,
+    fn2:  opts.bothForms === true ? 'CHANGELOG.long.md' : opts.bothForms,
+    ulen: opts.shortLength ?? 10
+  };
+
+}
+
+
+
+module.exports = { prescan_ui_lang, parse_short_length, resolve_output_plan };

--- a/src/js/test/cli_core.test.js
+++ b/src/js/test/cli_core.test.js
@@ -1,0 +1,66 @@
+const test   = require('node:test');
+const assert = require('node:assert');
+
+const { prescan_ui_lang, parse_short_length, resolve_output_plan } = require('../cli_core.js');
+
+test('prescan_ui_lang reads the --ui-lang=code form', () => {
+  assert.strictEqual(prescan_ui_lang(['node', 'cli.js', '--ui-lang=de']), 'de');
+});
+
+test('prescan_ui_lang reads the space-separated --ui-lang and -u forms', () => {
+  assert.strictEqual(prescan_ui_lang(['node', 'cli.js', '--ui-lang', 'fr']), 'fr');
+  assert.strictEqual(prescan_ui_lang(['node', 'cli.js', '-u', 'ja']), 'ja');
+});
+
+test('prescan_ui_lang returns null when no ui-lang flag is present', () => {
+  assert.strictEqual(prescan_ui_lang(['node', 'cli.js', '-l']), null);
+});
+
+test('prescan_ui_lang does not read a following flag, or a missing value, as the code', () => {
+  assert.strictEqual(prescan_ui_lang(['node', 'cli.js', '-u', '-l']), null);
+  assert.strictEqual(prescan_ui_lang(['node', 'cli.js', '--ui-lang']), null);
+});
+
+test('parse_short_length accepts a positive integer', () => {
+  assert.strictEqual(parse_short_length('25'), 25);
+  assert.strictEqual(parse_short_length('1'), 1);
+});
+
+test('parse_short_length rejects non-positive-integer values', () => {
+  assert.throws(() => parse_short_length('0'));
+  assert.throws(() => parse_short_length('-3'));
+  assert.throws(() => parse_short_length('2.5'));
+  assert.throws(() => parse_short_length('abc'));
+});
+
+test('resolve_output_plan defaults to the long form when no flag is given', () => {
+  const p = resolve_output_plan({ filename: 'CHANGELOG.md' });
+  assert.strictEqual(p.long,  true);
+  assert.strictEqual(p.short, false);
+  assert.strictEqual(p.fn,    'CHANGELOG.md');
+  assert.strictEqual(p.fn2,   undefined);
+  assert.strictEqual(p.ulen,  10);
+});
+
+test('resolve_output_plan honors -l and -s individually', () => {
+  const l = resolve_output_plan({ longForm: true });
+  assert.deepStrictEqual([l.long, l.short], [true, false]);
+
+  const s = resolve_output_plan({ shortForm: true });
+  assert.deepStrictEqual([s.long, s.short], [false, true]);
+});
+
+test('resolve_output_plan with -b selects both forms', () => {
+  const p = resolve_output_plan({ bothForms: true, filename: 'CHANGELOG.md' });
+  assert.strictEqual(p.long,  true);
+  assert.strictEqual(p.short, true);
+  assert.strictEqual(p.fn2,   'CHANGELOG.long.md');
+});
+
+test('resolve_output_plan keeps an explicit -b filename', () => {
+  assert.strictEqual(resolve_output_plan({ bothForms: 'HISTORY.md' }).fn2, 'HISTORY.md');
+});
+
+test('resolve_output_plan passes short_length through as ulen', () => {
+  assert.strictEqual(resolve_output_plan({ shortLength: 25 }).ulen, 25);
+});


### PR DESCRIPTION
## Summary

`cli.js` is a procedural entry-point script — it ran its whole flow at module load and exported nothing, so its decision logic was unreachable by `node --test`'s coverage instrumentation (it sat at ~54%).

This extracts the three pure functions into a new `src/js/cli_core.js`:

- `prescan_ui_lang(argv)` — find the UI language in raw argv before commander parses
- `parse_short_length(value)` — coerce and validate `-S`
- `resolve_output_plan(opts)` — the `-l` / `-s` / `-b` long/short/both decision

`cli.js` now requires them; it is a thinner shell. `cli_core.test.js` adds 11 tests covering all three at 100%. No behavior change — the build's self-run confirms the CLI still generates changelogs identically.

## Coverage

| metric | before | after |
|--------|--------|-------|
| line   | 93.0%  | 94.1% |
| branch | 85.0%  | 88.9% |
| `cli_core.js` | — | 100 / 100 / 100 |

`cli.js`'s own number drops, because the coverable logic moved out; what is left is the irreducible I/O shell — commander setup, `scan()`, the file-writing branches — exercised by the build self-run and the API integration tests rather than by unit tests.

## Test plan

- [ ] `npm test` — 69 pass (11 new)
- [ ] `npm run build` — succeeds (CLI behavior unchanged)

No version bump — internal refactor, no package behavior change.
