### PR TITLE
test: add fast-check property suite for the reflog parser

### DIFF
--- a/CHANGELOG.long.md
+++ b/CHANGELOG.long.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-8 merges; 11 releases
+10 merges; 12 releases
 
 
 
@@ -12,7 +12,7 @@ All notable changes to this project will be documented in this file.
 
 Published tags:
 
-<a href="#1__6__15">1.6.15</a>, <a href="#1__6__6">1.6.6</a>, <a href="#1__6__5">1.6.5</a>, <a href="#1__6__4">1.6.4</a>, <a href="#1__6__3">1.6.3</a>, <a href="#1__6__2">1.6.2</a>, <a href="#1__6__1">1.6.1</a>, <a href="#1__6__0">1.6.0</a>, <a href="#1__5__0">1.5.0</a>, <a href="#1__4__1">1.4.1</a>, <a href="#1__0__0">1.0.0</a>
+<a href="#1__6__16">1.6.16</a>, <a href="#1__6__15">1.6.15</a>, <a href="#1__6__6">1.6.6</a>, <a href="#1__6__5">1.6.5</a>, <a href="#1__6__4">1.6.4</a>, <a href="#1__6__3">1.6.3</a>, <a href="#1__6__2">1.6.2</a>, <a href="#1__6__1">1.6.1</a>, <a href="#1__6__0">1.6.0</a>, <a href="#1__5__0">1.5.0</a>, <a href="#1__4__1">1.4.1</a>, <a href="#1__0__0">1.0.0</a>
 
 
 
@@ -22,7 +22,173 @@ Published tags:
 
 &nbsp;
 
-## [Untagged] - May 18, 2026 3:41:17 PM
+## [Untagged] - May 20, 2026 4:50:13 PM
+
+Commit [5555714d943d48f9a4afb51609f7aed4a4c92191](https://github.com/StoneCypher/better_git_changelog/commit/5555714d943d48f9a4afb51609f7aed4a4c92191)
+
+Author: `John Haugeland <stonecypher@gmail.com>`
+
+Merges [dad8713, 539ecbb]
+
+  * Merge pull request #21 from StoneCypher/feat_26-05-18_ship-type-declarations_20
+  * Ship verified TypeScript type declarations
+
+
+
+
+&nbsp;
+
+&nbsp;
+
+## [Untagged] - May 20, 2026 4:45:08 PM
+
+Commit [539ecbb1f59b9bca371568bfa9c9cf14da41964a](https://github.com/StoneCypher/better_git_changelog/commit/539ecbb1f59b9bca371568bfa9c9cf14da41964a)
+
+Author: `John Haugeland <stonecypher@gmail.com>`
+
+  * ci: temporarily disable attw type-correctness gate
+  * The published @arethetypeswrong/cli@0.18.2 crashes with 'Cannot read properties of undefined (reading filename)' when invoked after 'npm install -g' in CI, on every matrix combo. The same version installed via 'npx' passes locally — so it appears to be a published-artifact / global-install bug, not our package's types. Disabling the gate to unblock builds. The .d.ts files are still generated and shipped; check-dts smoke test still gates the build; the check-types npm script is retained for manual local use against the linked attw fork.
+
+
+
+
+&nbsp;
+
+&nbsp;
+
+## [Untagged] - May 20, 2026 4:00:47 PM
+
+Commit [a6aee18330c2b03903a7448400ff6f11bc268ce2](https://github.com/StoneCypher/better_git_changelog/commit/a6aee18330c2b03903a7448400ff6f11bc268ce2)
+
+Author: `John Haugeland <stonecypher@gmail.com>`
+
+  * ci: pin attw to 0.18.2 (the published @latest crashes despite same version)
+  * @arethetypeswrong/cli@latest currently resolves to 0.18.2 but the install of the @latest tag crashes with 'Cannot read properties of undefined (reading filename)' on every matrix combo. Invoking @0.18.2 explicitly works (verified locally). Pin to that exact version until the published @latest is stable.
+
+
+
+
+&nbsp;
+
+&nbsp;
+
+## [Untagged] - May 18, 2026 10:50:04 PM
+
+Commit [4704025482be3c61e6a28e02bdc49005eb491a1e](https://github.com/StoneCypher/better_git_changelog/commit/4704025482be3c61e6a28e02bdc49005eb491a1e)
+
+Author: `John Haugeland <stonecypher@gmail.com>`
+
+  * test: add a TypeScript smoke test for the published declarations
+  * type-tests/smoke.ts imports the package by name (through the exports map, as a consumer would) and asserts the shipped .d.ts signatures, with @ts-expect-error blocks guarding against silent regression to any. Wired into build via the check-dts script.
+
+
+
+
+&nbsp;
+
+&nbsp;
+
+## [Untagged] - May 18, 2026 10:44:30 PM
+
+Commit [d53f342e6bec67b1156f92895b2b753f1df19fb9](https://github.com/StoneCypher/better_git_changelog/commit/d53f342e6bec67b1156f92895b2b753f1df19fb9)
+
+Author: `John Haugeland <stonecypher@gmail.com>`
+
+  * ci: provision attw and build before publishing
+  * The build job installs the published @arethetypeswrong/cli so build's new attw type-check can run. The release job now installs deps and runs the build before npm publish, so the generated dist/types declarations are present in the published tarball (the job previously published from a raw checkout).
+
+
+
+
+&nbsp;
+
+&nbsp;
+
+## [Untagged] - May 18, 2026 10:41:30 PM
+
+Commit [2c338a7bc9b0fcc0a74735422faa572181fbcb42](https://github.com/StoneCypher/better_git_changelog/commit/2c338a7bc9b0fcc0a74735422faa572181fbcb42)
+
+Author: `John Haugeland <stonecypher@gmail.com>`
+
+  * build: ship type declarations and trim the published package
+  * Adds types/exports pointing at the generated declarations, an engines field matching the documented Node requirement, and a files allowlist so the tarball no longer publishes test fixtures or grammar sources. build now generates declarations and gates on an attw check.
+
+
+
+
+&nbsp;
+
+&nbsp;
+
+## [Untagged] - May 18, 2026 10:39:10 PM
+
+Commit [c58746d55e1a3badc058fa005c9658bbf3acd7af](https://github.com/StoneCypher/better_git_changelog/commit/c58746d55e1a3badc058fa005c9658bbf3acd7af)
+
+Author: `John Haugeland <stonecypher@gmail.com>`
+
+  * build: add declaration-emit tsconfig and PEG parser typings
+  * tsconfig.json emits .d.ts from the JSDoc-annotated CommonJS sources into dist/types. reflog_parser.d.ts types the generated PEG parser; parse_rl is given an explicit @type so the emitted index.d.ts is self-contained.
+
+
+
+
+&nbsp;
+
+&nbsp;
+
+## [Untagged] - May 18, 2026 6:07:47 PM
+
+Commit [566c1a4227188598d6905ecf4c5ae1b852761353](https://github.com/StoneCypher/better_git_changelog/commit/566c1a4227188598d6905ecf4c5ae1b852761353)
+
+Author: `John Haugeland <stonecypher@gmail.com>`
+
+  * docs: add typed JSDoc and shared typedefs to index.js and i18n.js
+  * Completes the JSDoc type surface so tsc can emit accurate .d.ts files. Introduces ReflogEntry, ScanResult, ScanAllResult, and Translator typedefs and types every exported function's params and returns.
+
+
+
+
+&nbsp;
+
+&nbsp;
+
+## [Untagged] - May 18, 2026 3:57:36 PM
+
+Commit [dad87139fece628a2c19ade36659f0a04a68556d](https://github.com/StoneCypher/better_git_changelog/commit/dad87139fece628a2c19ade36659f0a04a68556d)
+
+Author: `John Haugeland <stonecypher@gmail.com>`
+
+Merges [8031880, 4f34e23]
+
+  * Merge pull request #19 from StoneCypher/refactor_26-05-18_extract-cli-core
+  * refactor: extract testable CLI logic into cli_core.js for coverage
+
+
+
+
+&nbsp;
+
+&nbsp;
+
+## [Untagged] - May 18, 2026 3:51:30 PM
+
+Commit [4f34e23888e539fe67add3305fe223bd43a25e0e](https://github.com/StoneCypher/better_git_changelog/commit/4f34e23888e539fe67add3305fe223bd43a25e0e)
+
+Author: `John Haugeland <stonecypher@gmail.com>`
+
+  * refactor: extract testable CLI logic into cli_core.js
+  * cli.js was a procedural entry-point script with no testable surface — its argv pre-scan, the -S validator, and the long/short/both decision logic were not reachable by the coverage instrumentation. Those three pure functions now live in cli_core.js with full unit tests (cli_core.test.js, 100% covered); cli.js requires them. No behavior change — the build's self-run confirms the CLI still works. Overall line coverage rises 93.0% to 94.1%, branch 85.0% to 88.9%.
+
+
+
+
+&nbsp;
+
+&nbsp;
+
+<a name="1__6__16" />
+
+## [1.6.16] - May 18, 2026 3:41:17 PM
 
 Commit [80318800063d3480e736f1448c3e5cd89424d764](https://github.com/StoneCypher/better_git_changelog/commit/80318800063d3480e736f1448c3e5cd89424d764)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-8 merges; 11 releases; Changelogging the last 10 commits; Full changelog at [CHANGELOG.long.md](CHANGELOG.long.md)
+10 merges; 12 releases; Changelogging the last 10 commits; Full changelog at [CHANGELOG.long.md](CHANGELOG.long.md)
 
 
 
@@ -12,7 +12,7 @@ All notable changes to this project will be documented in this file.
 
 Published tags:
 
-<a href="#1__6__15">1.6.15</a>, <a href="#1__6__6">1.6.6</a>, <a href="#1__6__5">1.6.5</a>, <a href="#1__6__4">1.6.4</a>, <a href="#1__6__3">1.6.3</a>, <a href="#1__6__2">1.6.2</a>, <a href="#1__6__1">1.6.1</a>, <a href="#1__6__0">1.6.0</a>, <a href="#1__5__0">1.5.0</a>, <a href="#1__4__1">1.4.1</a>, <a href="#1__0__0">1.0.0</a>
+<a href="#1__6__16">1.6.16</a>, <a href="#1__6__15">1.6.15</a>, <a href="#1__6__6">1.6.6</a>, <a href="#1__6__5">1.6.5</a>, <a href="#1__6__4">1.6.4</a>, <a href="#1__6__3">1.6.3</a>, <a href="#1__6__2">1.6.2</a>, <a href="#1__6__1">1.6.1</a>, <a href="#1__6__0">1.6.0</a>, <a href="#1__5__0">1.5.0</a>, <a href="#1__4__1">1.4.1</a>, <a href="#1__0__0">1.0.0</a>
 
 
 
@@ -22,13 +22,16 @@ Published tags:
 
 &nbsp;
 
-## [Untagged] - May 18, 2026 3:41:17 PM
+## [Untagged] - May 20, 2026 4:50:13 PM
 
-Commit [80318800063d3480e736f1448c3e5cd89424d764](https://github.com/StoneCypher/better_git_changelog/commit/80318800063d3480e736f1448c3e5cd89424d764)
+Commit [5555714d943d48f9a4afb51609f7aed4a4c92191](https://github.com/StoneCypher/better_git_changelog/commit/5555714d943d48f9a4afb51609f7aed4a4c92191)
 
 Author: `John Haugeland <stonecypher@gmail.com>`
 
-  * tag under node 24
+Merges [dad8713, 539ecbb]
+
+  * Merge pull request #21 from StoneCypher/feat_26-05-18_ship-type-declarations_20
+  * Ship verified TypeScript type declarations
 
 
 
@@ -37,16 +40,14 @@ Author: `John Haugeland <stonecypher@gmail.com>`
 
 &nbsp;
 
-## [Untagged] - May 18, 2026 2:22:25 PM
+## [Untagged] - May 20, 2026 4:45:08 PM
 
-Commit [5ae8f70f0dca34e29de777379e07db06ad3b884d](https://github.com/StoneCypher/better_git_changelog/commit/5ae8f70f0dca34e29de777379e07db06ad3b884d)
+Commit [539ecbb1f59b9bca371568bfa9c9cf14da41964a](https://github.com/StoneCypher/better_git_changelog/commit/539ecbb1f59b9bca371568bfa9c9cf14da41964a)
 
 Author: `John Haugeland <stonecypher@gmail.com>`
 
-Merges [086752a, 0e2a202]
-
-  * Merge pull request #18 from StoneCypher/ci_26-05-18_release-guard
-  * ci: skip release and publish when the version is unchanged
+  * ci: temporarily disable attw type-correctness gate
+  * The published @arethetypeswrong/cli@0.18.2 crashes with 'Cannot read properties of undefined (reading filename)' when invoked after 'npm install -g' in CI, on every matrix combo. The same version installed via 'npx' passes locally — so it appears to be a published-artifact / global-install bug, not our package's types. Disabling the gate to unblock builds. The .d.ts files are still generated and shipped; check-dts smoke test still gates the build; the check-types npm script is retained for manual local use against the linked attw fork.
 
 
 
@@ -55,14 +56,14 @@ Merges [086752a, 0e2a202]
 
 &nbsp;
 
-## [Untagged] - May 18, 2026 1:58:44 PM
+## [Untagged] - May 20, 2026 4:00:47 PM
 
-Commit [0e2a2025d6fba342b2d06acbeffcc85456df6a97](https://github.com/StoneCypher/better_git_changelog/commit/0e2a2025d6fba342b2d06acbeffcc85456df6a97)
+Commit [a6aee18330c2b03903a7448400ff6f11bc268ce2](https://github.com/StoneCypher/better_git_changelog/commit/a6aee18330c2b03903a7448400ff6f11bc268ce2)
 
 Author: `John Haugeland <stonecypher@gmail.com>`
 
-  * ci: skip release and publish when the version is unchanged
-  * The release job ran on every owner push to main and unconditionally created a GitHub release for package.json's version. A push that does not bump the version (such as a CI-only change) re-ran it for an already-released version, and actions/create-release failed with 'tag_name already_exists' (npm publish would reject the duplicate too). A new step checks whether the version's tag already exists on origin; push-tags, create-release, upgrade-npm and publish now run only when the version is new.
+  * ci: pin attw to 0.18.2 (the published @latest crashes despite same version)
+  * @arethetypeswrong/cli@latest currently resolves to 0.18.2 but the install of the @latest tag crashes with 'Cannot read properties of undefined (reading filename)' on every matrix combo. Invoking @0.18.2 explicitly works (verified locally). Pin to that exact version until the published @latest is stable.
 
 
 
@@ -71,16 +72,14 @@ Author: `John Haugeland <stonecypher@gmail.com>`
 
 &nbsp;
 
-## [Untagged] - May 18, 2026 11:01:29 AM
+## [Untagged] - May 18, 2026 10:50:04 PM
 
-Commit [086752a9aa8b91d27b334384c7a309c25e288941](https://github.com/StoneCypher/better_git_changelog/commit/086752a9aa8b91d27b334384c7a309c25e288941)
+Commit [4704025482be3c61e6a28e02bdc49005eb491a1e](https://github.com/StoneCypher/better_git_changelog/commit/4704025482be3c61e6a28e02bdc49005eb491a1e)
 
 Author: `John Haugeland <stonecypher@gmail.com>`
 
-Merges [b9de48f, 5353e38]
-
-  * Merge pull request #17 from StoneCypher/ci_26-05-18_npm-trusted-publishing
-  * ci: publish to npm via OIDC trusted publishing
+  * test: add a TypeScript smoke test for the published declarations
+  * type-tests/smoke.ts imports the package by name (through the exports map, as a consumer would) and asserts the shipped .d.ts signatures, with @ts-expect-error blocks guarding against silent regression to any. Wired into build via the check-dts script.
 
 
 
@@ -89,14 +88,14 @@ Merges [b9de48f, 5353e38]
 
 &nbsp;
 
-## [Untagged] - May 18, 2026 11:00:01 AM
+## [Untagged] - May 18, 2026 10:44:30 PM
 
-Commit [5353e38704c6d5dbf12af00931544c9af322e0c9](https://github.com/StoneCypher/better_git_changelog/commit/5353e38704c6d5dbf12af00931544c9af322e0c9)
+Commit [d53f342e6bec67b1156f92895b2b753f1df19fb9](https://github.com/StoneCypher/better_git_changelog/commit/d53f342e6bec67b1156f92895b2b753f1df19fb9)
 
 Author: `John Haugeland <stonecypher@gmail.com>`
 
-  * ci: publish to npm via OIDC trusted publishing
-  * The release job published with a long-lived NODE_AUTH_TOKEN, which no longer works under npm's current auth model. It now uses trusted publishing: an id-token:write permission lets npm authenticate via GitHub's OIDC, an upgrade-npm step ensures npm is new enough (>= 11.5.1) to support it, and the NODE_AUTH_TOKEN secret reference is removed. Also bumps actions/checkout (v1 and v2) and actions/setup-node (v1) to v4. The package's trusted publisher must be registered on npmjs.com before the next release.
+  * ci: provision attw and build before publishing
+  * The build job installs the published @arethetypeswrong/cli so build's new attw type-check can run. The release job now installs deps and runs the build before npm publish, so the generated dist/types declarations are present in the published tarball (the job previously published from a raw checkout).
 
 
 
@@ -105,18 +104,14 @@ Author: `John Haugeland <stonecypher@gmail.com>`
 
 &nbsp;
 
-<a name="1__6__15" />
+## [Untagged] - May 18, 2026 10:41:30 PM
 
-## [1.6.15] - May 18, 2026 10:47:50 AM
-
-Commit [b9de48f2cc9ee560f9845589b2673a3a093c8161](https://github.com/StoneCypher/better_git_changelog/commit/b9de48f2cc9ee560f9845589b2673a3a093c8161)
+Commit [2c338a7bc9b0fcc0a74735422faa572181fbcb42](https://github.com/StoneCypher/better_git_changelog/commit/2c338a7bc9b0fcc0a74735422faa572181fbcb42)
 
 Author: `John Haugeland <stonecypher@gmail.com>`
 
-Merges [5883848, 42ac85b]
-
-  * Merge pull request #16 from StoneCypher/fix_26-05-18_short-length
-  * fix: land bug fixes 2-10 on main
+  * build: ship type declarations and trim the published package
+  * Adds types/exports pointing at the generated declarations, an engines field matching the documented Node requirement, and a files allowlist so the tarball no longer publishes test fixtures or grammar sources. build now generates declarations and gates on an attw check.
 
 
 
@@ -125,14 +120,14 @@ Merges [5883848, 42ac85b]
 
 &nbsp;
 
-## [Untagged] - May 18, 2026 10:08:03 AM
+## [Untagged] - May 18, 2026 10:39:10 PM
 
-Commit [42ac85b8a5a22ffd1579210ada68ad6de517df6b](https://github.com/StoneCypher/better_git_changelog/commit/42ac85b8a5a22ffd1579210ada68ad6de517df6b)
+Commit [c58746d55e1a3badc058fa005c9658bbf3acd7af](https://github.com/StoneCypher/better_git_changelog/commit/c58746d55e1a3badc058fa005c9658bbf3acd7af)
 
 Author: `John Haugeland <stonecypher@gmail.com>`
 
-  * fix: reject a non-numeric --short-length instead of emptying the changelog
-  * opts.shortLength was an unvalidated string; -S abc became slice(0, NaN), silently producing an empty changelog with no error. -S now has a commander argument parser that coerces the value to a positive integer and raises InvalidArgumentError on anything else, so a bad value fails the run loudly.
+  * build: add declaration-emit tsconfig and PEG parser typings
+  * tsconfig.json emits .d.ts from the JSDoc-annotated CommonJS sources into dist/types. reflog_parser.d.ts types the generated PEG parser; parse_rl is given an explicit @type so the emitted index.d.ts is self-contained.
 
 
 
@@ -141,14 +136,14 @@ Author: `John Haugeland <stonecypher@gmail.com>`
 
 &nbsp;
 
-## [Untagged] - May 18, 2026 9:55:25 AM
+## [Untagged] - May 18, 2026 6:07:47 PM
 
-Commit [c5e90a724cdf065a41b7a08b6db20755d8b7a3f4](https://github.com/StoneCypher/better_git_changelog/commit/c5e90a724cdf065a41b7a08b6db20755d8b7a3f4)
+Commit [566c1a4227188598d6905ecf4c5ae1b852761353](https://github.com/StoneCypher/better_git_changelog/commit/566c1a4227188598d6905ecf4c5ae1b852761353)
 
 Author: `John Haugeland <stonecypher@gmail.com>`
 
-  * fix: count merge commits, not all commits, in the summary line
-  * The changelog summary rendered data.reflog.length through the 'merges' string, so it reported every commit as a merge (e.g. '441 merges' when 441 was the total entry count). It now counts only entries that actually carry a merge field.
+  * docs: add typed JSDoc and shared typedefs to index.js and i18n.js
+  * Completes the JSDoc type surface so tsc can emit accurate .d.ts files. Introduces ReflogEntry, ScanResult, ScanAllResult, and Translator typedefs and types every exported function's params and returns.
 
 
 
@@ -157,31 +152,29 @@ Author: `John Haugeland <stonecypher@gmail.com>`
 
 &nbsp;
 
-<a name="1__6__6" />
+## [Untagged] - May 18, 2026 3:57:36 PM
 
-## [1.6.6] - May 18, 2026 9:49:04 AM
-
-Commit [58838484bd9b901bb7cde398c854e67df3feb7d9](https://github.com/StoneCypher/better_git_changelog/commit/58838484bd9b901bb7cde398c854e67df3feb7d9)
+Commit [dad87139fece628a2c19ade36659f0a04a68556d](https://github.com/StoneCypher/better_git_changelog/commit/dad87139fece628a2c19ade36659f0a04a68556d)
 
 Author: `John Haugeland <stonecypher@gmail.com>`
 
-Merges [bf0422f, 6673f2e]
+Merges [8031880, 4f34e23]
 
-  * Merge pull request #6 from StoneCypher/fix_26-05-18_non-semver-tags
-  * fix: tolerate non-semver tags in changelog generation
-
-
+  * Merge pull request #19 from StoneCypher/refactor_26-05-18_extract-cli-core
+  * refactor: extract testable CLI logic into cli_core.js for coverage
 
 
-&nbsp;
+
 
 &nbsp;
 
-## [Untagged] - May 18, 2026 9:48:07 AM
+&nbsp;
 
-Commit [1025797c006f88bb9f724467a9c636729cd22254](https://github.com/StoneCypher/better_git_changelog/commit/1025797c006f88bb9f724467a9c636729cd22254)
+## [Untagged] - May 18, 2026 3:51:30 PM
+
+Commit [4f34e23888e539fe67add3305fe223bd43a25e0e](https://github.com/StoneCypher/better_git_changelog/commit/4f34e23888e539fe67add3305fe223bd43a25e0e)
 
 Author: `John Haugeland <stonecypher@gmail.com>`
 
-  * refactor: remove dead get_commit_message_for_hash
-  * get_commit_message_for_hash was never called and never exported, so it was unreachable code — and it carried the same string-interpolated execSync injection pattern that was fixed in tag_to_hash. Removing it eliminates both. No test accompanies this change because there was nothing reachable to test; the existing suite still passes, confirming nothing depended on it.
+  * refactor: extract testable CLI logic into cli_core.js
+  * cli.js was a procedural entry-point script with no testable surface — its argv pre-scan, the -S validator, and the long/short/both decision logic were not reachable by the coverage instrumentation. Those three pure functions now live in cli_core.js with full unit tests (cli_core.test.js, 100% covered); cli.js requires them. No behavior change — the build's self-run confirms the CLI still works. Overall line coverage rises 93.0% to 94.1%, branch 85.0% to 88.9%.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "better_git_changelog",
-  "version": "1.6.3",
+  "version": "1.6.16",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "better_git_changelog",
-      "version": "1.6.3",
+      "version": "1.6.16",
       "license": "MIT",
       "dependencies": {
         "arg-parser": "^1.2.0",
@@ -16,10 +16,14 @@
         "better_git_changelog": "src/js/cli.js"
       },
       "devDependencies": {
+        "fast-check": "^4.8.0",
         "pegjs": "^0.10.0",
         "semver": "^7.5.4",
         "typescript": "^6.0.3",
         "typescript-language-server": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/arg-parser": {
@@ -36,6 +40,29 @@
       "integrity": "sha512-e2i4wANQiSXgnrBlIatyHtP1odfUp0BbV5Y5nEGbxtIrStkEOAAzCUirvLBNXHLr7kwLvJl6V+4V3XV9x7Wd9w==",
       "engines": {
         "node": "^12.20.0 || >=14"
+      }
+    },
+    "node_modules/fast-check": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.8.0.tgz",
+      "integrity": "sha512-GOJ158CUMnN6cSahsv4+ExARvIDuzzinFjkp0E9WtiBa5zcVeLozVkWaE4IzFcc+Y48Wp1EDlUZsXRyAztQcSg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "pure-rand": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=12.17.0"
       }
     },
     "node_modules/lru-cache": {
@@ -61,6 +88,23 @@
       "engines": {
         "node": ">=0.10"
       }
+    },
+    "node_modules/pure-rand": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-8.4.0.tgz",
+      "integrity": "sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/semver": {
       "version": "7.5.4",
@@ -122,6 +166,15 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-9.2.0.tgz",
       "integrity": "sha512-e2i4wANQiSXgnrBlIatyHtP1odfUp0BbV5Y5nEGbxtIrStkEOAAzCUirvLBNXHLr7kwLvJl6V+4V3XV9x7Wd9w=="
     },
+    "fast-check": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.8.0.tgz",
+      "integrity": "sha512-GOJ158CUMnN6cSahsv4+ExARvIDuzzinFjkp0E9WtiBa5zcVeLozVkWaE4IzFcc+Y48Wp1EDlUZsXRyAztQcSg==",
+      "dev": true,
+      "requires": {
+        "pure-rand": "^8.0.0"
+      }
+    },
     "lru-cache": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
@@ -135,6 +188,12 @@
       "version": "0.10.0",
       "resolved": "https://registry.npmjs.org/pegjs/-/pegjs-0.10.0.tgz",
       "integrity": "sha1-z4uvrm7d/0tafvsYUmnqr0YQ3b0=",
+      "dev": true
+    },
+    "pure-rand": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-8.4.0.tgz",
+      "integrity": "sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A==",
       "dev": true
     },
     "semver": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "better_git_changelog",
-  "version": "1.6.16",
+  "version": "1.6.17",
   "description": "Make a changelog from git commits, tags, and releases",
   "main": "src/js/index.js",
   "types": "./dist/types/index.d.ts",
@@ -28,8 +28,12 @@
     "check-types": "attw --pack . --profile node16",
     "check-dts": "tsc -p type-tests/tsconfig.json",
     "build": "npm run clean && npm run peg && npm run check-locales && npm run types && npm run check-dts && npm run self",
-    "test": "node --test \"src/js/test/*.test.js\"",
-    "coverage": "node --test --experimental-test-coverage --test-coverage-exclude=\"src/js/reflog_parser.js\" \"src/js/test/*.test.js\""
+    "test": "node --test \"src/js/test/**/*.test.js\"",
+    "test:unit": "node --test \"src/js/test/*.test.js\"",
+    "test:property": "node --test \"src/js/test/property/*.test.js\"",
+    "coverage": "node --test --experimental-test-coverage --test-coverage-exclude=\"src/js/reflog_parser.js\" \"src/js/test/**/*.test.js\"",
+    "coverage:unit": "node --test --experimental-test-coverage --test-coverage-exclude=\"src/js/reflog_parser.js\" \"src/js/test/*.test.js\"",
+    "coverage:property": "node --test --experimental-test-coverage \"src/js/test/property/*.test.js\""
   },
   "repository": {
     "type": "git",
@@ -53,6 +57,7 @@
   },
   "homepage": "https://github.com/StoneCypher/better_git_changelog#readme",
   "devDependencies": {
+    "fast-check": "^4.8.0",
     "pegjs": "^0.10.0",
     "semver": "^7.5.4",
     "typescript": "^6.0.3",

--- a/src/js/test/parser.test.js
+++ b/src/js/test/parser.test.js
@@ -59,3 +59,23 @@ test('parse_rl handles an octopus merge (three or more parents)', () => {
   assert.strictEqual(parsed.length, 1);
   assert.deepStrictEqual(parsed[0].merge, ['aaaaaaa', 'bbbbbbb', 'ccccccc']);
 });
+
+// Regression: this is the exact input shape that failed in
+// better_git_changelog@1.6.3, reported on 2026-05-22 from the issue_tree
+// project after the user ran `git stash push -u`. A stash-with-untracked
+// creates a three-parent merge commit (tip-of-HEAD, index tree, untracked
+// tree) which the pre-fix MergeRow rejected, having accepted exactly two
+// parent hashes. Fixed in e23fbdc, first released in 1.6.6.
+test('parse_rl handles a 3-parent stash-with-untracked commit (bug-report shape)', () => {
+  const stashed =
+    'commit 222c2b61bfa58ee82b1d5e2f525cfab3b45bd325\n' +
+    'Merge: 232e461 beef2bb e979fe1\n' +
+    'Author: John Haugeland <stonecypher@gmail.com>\n' +
+    'Date:   Fri May 22 01:51:14 2026 -0700\n' +
+    '\n' +
+    '    WIP on main: 232e461 add a\n' +
+    '\n';
+  const parsed = parse_rl(stashed);
+  assert.strictEqual(parsed.length, 1);
+  assert.deepStrictEqual(parsed[0].merge, ['232e461', 'beef2bb', 'e979fe1']);
+});

--- a/src/js/test/property/parser.property.test.js
+++ b/src/js/test/property/parser.property.test.js
@@ -1,0 +1,192 @@
+const test   = require('node:test');
+const assert = require('node:assert');
+const fc     = require('fast-check');
+
+const { parse_rl } = require('../../index.js');
+
+
+
+/**
+ * Property-based tests for the reflog parser.
+ *
+ * The example-based suite in ../parser.test.js asserts behavior on a single
+ * captured `git log --reflog` fixture. That style depends on the fixture
+ * containing the shapes worth testing — the octopus-merge bug (May 2026) is
+ * the canonical proof it does not. These tests instead generate plausible
+ * reflog inputs at runtime and assert structural invariants that must hold
+ * for every well-formed input the parser is expected to accept.
+ */
+
+
+
+// ---------------------------------------------------------------------------
+// Generators
+// ---------------------------------------------------------------------------
+
+// fast-check 4.x removed `hexaString`; build it from `string` + unit.
+const hexChar = fc.constantFrom(
+  '0','1','2','3','4','5','6','7','8','9','a','b','c','d','e','f'
+);
+
+const shortHash = fc.string({ unit: hexChar, minLength: 7,  maxLength: 7  });
+const fullHash  = fc.string({ unit: hexChar, minLength: 40, maxLength: 40 });
+
+// Any single-line string. Production `git log` is LF-only; the fixture
+// loader normalizes CR via .replace(/\r\n/g, '\n'), so we likewise strip
+// CR/LF from generated single-line fields rather than rejecting them.
+const lineText = fc.string().map(s => s.replace(/[\r\n]/g, ' '));
+
+// A date string the grammar's `new Date(s).getTime()` returns a finite
+// number for. ISO 8601 is always parseable in V8.
+const parseableDate = fc.date({
+  min:            new Date('1990-01-01T00:00:00Z'),
+  max:            new Date('2100-01-01T00:00:00Z'),
+  noInvalidDate:  true
+}).map(d => d.toISOString());
+
+// A merge commit has 2 or more parents. The bug surface starts at 3.
+const mergeParents = fc.array(shortHash, { minLength: 2, maxLength: 6 });
+
+// One body paragraph: a run of zero or more text lines.
+const paragraph = fc.array(lineText, { minLength: 0, maxLength: 4 });
+
+// Body: zero or more paragraphs, blank-line separated on render.
+const body = fc.array(paragraph, { minLength: 0, maxLength: 3 });
+
+const commit = fc.record({
+  hash:    fullHash,
+  parents: fc.option(mergeParents, { nil: undefined }),
+  author:  lineText,
+  date:    parseableDate,
+  body:    body
+});
+
+const reflog = fc.array(commit, { minLength: 1, maxLength: 8 });
+
+
+
+// ---------------------------------------------------------------------------
+// Renderer: structured commit list -> raw reflog text the parser accepts.
+//
+// Mirrors `git --no-pager log` output, plus the `.trim() + '\n\n'` framing
+// applied by get_reflog_data() before handing the text to the parser.
+// ---------------------------------------------------------------------------
+
+function renderCommit({ hash, parents, author, date, body }) {
+
+  const headers =
+    `commit ${hash}\n` +
+    (parents ? `Merge: ${parents.join(' ')}\n` : '') +
+    `Author: ${author}\n` +
+    `Date:   ${date}\n` +
+    `\n`;
+
+  const renderedBody = body
+    .map(para => para.map(line => '    ' + line).join('\n'))
+    .filter(s => s.length > 0)
+    .join('\n\n');
+
+  return headers + (renderedBody.length ? renderedBody + '\n' : '');
+
+}
+
+function renderReflog(commits) {
+  return commits.map(renderCommit).join('\n').trim() + '\n\n';
+}
+
+
+
+// ---------------------------------------------------------------------------
+// Properties
+// ---------------------------------------------------------------------------
+
+test('parse_rl never throws on any well-formed reflog', () => {
+  fc.assert(fc.property(reflog, commits => {
+    parse_rl(renderReflog(commits));
+  }));
+});
+
+
+test('parse_rl preserves the commit count', () => {
+  fc.assert(fc.property(reflog, commits => {
+    const parsed = parse_rl(renderReflog(commits));
+    assert.strictEqual(parsed.length, commits.length);
+  }));
+});
+
+
+test('parse_rl preserves commit hashes in order', () => {
+  fc.assert(fc.property(reflog, commits => {
+    const parsed = parse_rl(renderReflog(commits));
+    assert.deepStrictEqual(
+      parsed.map(p => p.commit_hash),
+      commits.map(c => c.hash)
+    );
+  }));
+});
+
+
+test('parse_rl preserves the parent list of every merge commit', () => {
+  fc.assert(fc.property(reflog, commits => {
+    const parsed = parse_rl(renderReflog(commits));
+    parsed.forEach((p, i) => {
+      if (commits[i].parents) {
+        assert.deepStrictEqual(p.merge, commits[i].parents);
+      }
+    });
+  }));
+});
+
+
+test('parse_rl omits the merge property for non-merge commits', () => {
+  fc.assert(fc.property(reflog, commits => {
+    const parsed = parse_rl(renderReflog(commits));
+    parsed.forEach((p, i) => {
+      if (!commits[i].parents) {
+        assert.strictEqual('merge' in p, false);
+      }
+    });
+  }));
+});
+
+
+test('parse_rl returns a finite millisecond timestamp for every commit', () => {
+  fc.assert(fc.property(reflog, commits => {
+    const parsed = parse_rl(renderReflog(commits));
+    parsed.forEach(p => {
+      assert.ok(Number.isFinite(p.date));
+    });
+  }));
+});
+
+
+test('parse_rl preserves author lines verbatim', () => {
+  fc.assert(fc.property(reflog, commits => {
+    const parsed = parse_rl(renderReflog(commits));
+    parsed.forEach((p, i) => {
+      assert.strictEqual(p.author, commits[i].author);
+    });
+  }));
+});
+
+
+// Focused regression: bias generation toward the parent-count dimension so a
+// hard-coded parent count fails fast and shrinks to a minimal counter-example.
+test('parse_rl handles merges with two through twelve parents', () => {
+
+  const widerMergeCommit = fc.record({
+    hash:    fullHash,
+    parents: fc.integer({ min: 2, max: 12 })
+              .chain(n => fc.array(shortHash, { minLength: n, maxLength: n })),
+    author:  lineText,
+    date:    parseableDate,
+    body:    body
+  });
+
+  fc.assert(fc.property(widerMergeCommit, c => {
+    const parsed = parse_rl(renderReflog([c]));
+    assert.strictEqual(parsed.length, 1);
+    assert.deepStrictEqual(parsed[0].merge, c.parents);
+  }));
+
+});


### PR DESCRIPTION
## Summary

- Adds a property-based test suite at `src/js/test/property/parser.property.test.js` (8 properties, powered by `fast-check@4.8.0`) that generates plausible reflog inputs at runtime and asserts the parser preserves count, hash order, merge parents (including 2..12), author text, and finite timestamps — plus a smoke property that it never throws on any well-formed input. This is the class of test that would have caught the 3+ parent `Merge:` bug fixed in e23fbdc, instead of having it reported by a downstream consumer.
- Adds one explicit regression in `parser.test.js` mirroring the bug-report's exact 3-parent stash-with-untracked `Merge:` line, so the specific failing input is permanently pinned.
- Splits the npm scripts into `test` / `test:unit` / `test:property` and matching `coverage` variants. `coverage:property` deliberately omits the `reflog_parser.js` exclusion that the unit variant keeps, since the generated parser is the system under test for the property suite.

## Test plan

- [x] `npm test` — full suite: 78 passing (was 69)
- [x] `npm run test:unit` — runs only the example-based tests, untouched
- [x] `npm run test:property` — runs only the new property suite
- [x] `npm run build` — clean → peg → check-locales → tsc → check-dts → self, all green
- [x] No IDE diagnostics on touched files
- [x] Version bump 1.6.16 → 1.6.17 (patch, test infra)