### PR TITLE
ci: run the test suite in CI

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -43,7 +43,7 @@ jobs:
         node-version: 24
     - name: npm install, build, and test
       run: |
-        npm install && npm run build
+        npm install && npm run build && npm test
       env:
         CI: true
 

--- a/CHANGELOG.long.md
+++ b/CHANGELOG.long.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-12 merges; 13 releases
+13 merges; 13 releases
 
 
 
@@ -14,6 +14,66 @@ Published tags:
 
 <a href="#1__6__17">1.6.17</a>, <a href="#1__6__16">1.6.16</a>, <a href="#1__6__15">1.6.15</a>, <a href="#1__6__6">1.6.6</a>, <a href="#1__6__5">1.6.5</a>, <a href="#1__6__4">1.6.4</a>, <a href="#1__6__3">1.6.3</a>, <a href="#1__6__2">1.6.2</a>, <a href="#1__6__1">1.6.1</a>, <a href="#1__6__0">1.6.0</a>, <a href="#1__5__0">1.5.0</a>, <a href="#1__4__1">1.4.1</a>, <a href="#1__0__0">1.0.0</a>
 
+
+
+
+
+&nbsp;
+
+&nbsp;
+
+## [Untagged] - May 23, 2026 12:10:24 AM
+
+Commit [8af57bc0e39055c7c31833ff24ba78cf3792d25f](https://github.com/StoneCypher/better_git_changelog/commit/8af57bc0e39055c7c31833ff24ba78cf3792d25f)
+
+Author: `John Haugeland <stonecypher@gmail.com>`
+
+  * ci: run the test suite in CI
+  * The build step was named "npm install, build, and test" but its body
+only ran `npm install && npm run build`, so assertions never executed
+on push. This is the root pattern that let the 3+ parent Merge: row
+bug ship in 1.6.3 without local catch.
+  * Append `&& npm test` to the run line so the full node:test suite
+runs on every push across the existing node/OS matrix. The step
+name is now accurate.
+  * Closes #23
+
+
+
+
+&nbsp;
+
+&nbsp;
+
+## [Untagged] - May 23, 2026 2:10:17 AM
+
+Commit [a208c36ab119fd3cbd8efde74e7840740de434ee](https://github.com/StoneCypher/better_git_changelog/commit/a208c36ab119fd3cbd8efde74e7840740de434ee)
+
+Author: `John Haugeland <stonecypher@gmail.com>`
+
+Merges [94d66c7, 42fd16a]
+
+  * Merge pull request #26 from StoneCypher/ci_26-05-23_pin-node-24
+  * ci: pin setup-node to 24 across the matrix
+
+
+
+
+&nbsp;
+
+&nbsp;
+
+## [Untagged] - May 23, 2026 12:07:54 AM
+
+Commit [42fd16a2b374ba8e81447e5b3c476039b328b8a8](https://github.com/StoneCypher/better_git_changelog/commit/42fd16a2b374ba8e81447e5b3c476039b328b8a8)
+
+Author: `John Haugeland <stonecypher@gmail.com>`
+
+  * ci: pin setup-node to 24 across the matrix
+  * The setup-node step was reading matrix.node-version, so each matrix
+row provisioned the Node version it declared. Replace both references
+with the literal 24 so every row uses Node 24 regardless of the
+matrix entry's node-version field.
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-12 merges; 13 releases; Changelogging the last 10 commits; Full changelog at [CHANGELOG.long.md](CHANGELOG.long.md)
+13 merges; 13 releases; Changelogging the last 10 commits; Full changelog at [CHANGELOG.long.md](CHANGELOG.long.md)
 
 
 
@@ -14,6 +14,66 @@ Published tags:
 
 <a href="#1__6__17">1.6.17</a>, <a href="#1__6__16">1.6.16</a>, <a href="#1__6__15">1.6.15</a>, <a href="#1__6__6">1.6.6</a>, <a href="#1__6__5">1.6.5</a>, <a href="#1__6__4">1.6.4</a>, <a href="#1__6__3">1.6.3</a>, <a href="#1__6__2">1.6.2</a>, <a href="#1__6__1">1.6.1</a>, <a href="#1__6__0">1.6.0</a>, <a href="#1__5__0">1.5.0</a>, <a href="#1__4__1">1.4.1</a>, <a href="#1__0__0">1.0.0</a>
 
+
+
+
+
+&nbsp;
+
+&nbsp;
+
+## [Untagged] - May 23, 2026 12:10:24 AM
+
+Commit [8af57bc0e39055c7c31833ff24ba78cf3792d25f](https://github.com/StoneCypher/better_git_changelog/commit/8af57bc0e39055c7c31833ff24ba78cf3792d25f)
+
+Author: `John Haugeland <stonecypher@gmail.com>`
+
+  * ci: run the test suite in CI
+  * The build step was named "npm install, build, and test" but its body
+only ran `npm install && npm run build`, so assertions never executed
+on push. This is the root pattern that let the 3+ parent Merge: row
+bug ship in 1.6.3 without local catch.
+  * Append `&& npm test` to the run line so the full node:test suite
+runs on every push across the existing node/OS matrix. The step
+name is now accurate.
+  * Closes #23
+
+
+
+
+&nbsp;
+
+&nbsp;
+
+## [Untagged] - May 23, 2026 2:10:17 AM
+
+Commit [a208c36ab119fd3cbd8efde74e7840740de434ee](https://github.com/StoneCypher/better_git_changelog/commit/a208c36ab119fd3cbd8efde74e7840740de434ee)
+
+Author: `John Haugeland <stonecypher@gmail.com>`
+
+Merges [94d66c7, 42fd16a]
+
+  * Merge pull request #26 from StoneCypher/ci_26-05-23_pin-node-24
+  * ci: pin setup-node to 24 across the matrix
+
+
+
+
+&nbsp;
+
+&nbsp;
+
+## [Untagged] - May 23, 2026 12:07:54 AM
+
+Commit [42fd16a2b374ba8e81447e5b3c476039b328b8a8](https://github.com/StoneCypher/better_git_changelog/commit/42fd16a2b374ba8e81447e5b3c476039b328b8a8)
+
+Author: `John Haugeland <stonecypher@gmail.com>`
+
+  * ci: pin setup-node to 24 across the matrix
+  * The setup-node step was reading matrix.node-version, so each matrix
+row provisioned the Node version it declared. Replace both references
+with the literal 24 so every row uses Node 24 regardless of the
+matrix entry's node-version field.
 
 
 
@@ -171,81 +231,3 @@ in PR #22 is mis-scoped against this class of bug (generator
 hardcoded to seven chars, matching the parser) and will be addressed
 in a follow-up.
   * Closes #30
-
-
-
-
-&nbsp;
-
-&nbsp;
-
-## [Untagged] - May 23, 2026 12:24:49 AM
-
-Commit [bfb13e576e848578d739cb54c9dd6973c0d2f0a3](https://github.com/StoneCypher/better_git_changelog/commit/bfb13e576e848578d739cb54c9dd6973c0d2f0a3)
-
-Author: `John Haugeland <stonecypher@gmail.com>`
-
-  * fix: accept short hashes longer than 7 chars in Merge: rows
-  * The PEG grammar's ShortHash production hardcoded exactly seven hex
-characters. Once a repository's object set crosses git's auto-abbrev
-threshold (typically mid-thousands of commits, shape-dependent), git
-log emits 8+ character short hashes and the parser dies at the 8th
-character with "expected newline". Reported against 1.6.16 with a
-b0eda7bf shape; users worked around it with core.abbrev=7.
-  * Widen ShortHash to `Hex Hex Hex Hex Hex*` — four mandatory hex
-characters (git's documented --abbrev minimum) plus zero-or-more
-additional. PEG's greedy match plus the existing space/newline
-terminator in MergeRow keeps it unambiguous in context. The
-regenerated reflog_parser.js is included.
-  * This is the second bug in the same MergeRow area; the first
-(3+ parents) was fixed in e23fbdc / 1.6.6. The property suite added
-in PR #22 is mis-scoped against this class of bug (generator
-hardcoded to seven chars, matching the parser) and will be addressed
-in a follow-up.
-  * Closes #30
-
-
-
-
-&nbsp;
-
-&nbsp;
-
-## [Untagged] - May 23, 2026 12:10:24 AM
-
-Commit [c4c09fa48ff7776de6999091a31c10d012a0323a](https://github.com/StoneCypher/better_git_changelog/commit/c4c09fa48ff7776de6999091a31c10d012a0323a)
-
-Author: `John Haugeland <stonecypher@gmail.com>`
-
-  * ci: run the test suite in CI
-  * The build step was named "npm install, build, and test" but its body
-only ran `npm install && npm run build`, so assertions never executed
-on push. This is the root pattern that let the 3+ parent Merge: row
-bug ship in 1.6.3 without local catch.
-  * Append `&& npm test` to the run line so the full node:test suite
-runs on every push across the existing node/OS matrix. The step
-name is now accurate.
-  * Closes #23
-
-
-
-
-&nbsp;
-
-&nbsp;
-
-## [Untagged] - May 23, 2026 12:10:24 AM
-
-Commit [57d7f49f02a9e614f5b50ae7a0211f0eee5f4ea7](https://github.com/StoneCypher/better_git_changelog/commit/57d7f49f02a9e614f5b50ae7a0211f0eee5f4ea7)
-
-Author: `John Haugeland <stonecypher@gmail.com>`
-
-  * ci: run the test suite in CI
-  * The build step was named "npm install, build, and test" but its body
-only ran `npm install && npm run build`, so assertions never executed
-on push. This is the root pattern that let the 3+ parent Merge: row
-bug ship in 1.6.3 without local catch.
-  * Append `&& npm test` to the run line so the full node:test suite
-runs on every push across the existing node/OS matrix. The step
-name is now accurate.
-  * Closes #23


### PR DESCRIPTION
## Summary

The build step in `node.js.yml` was named "npm install, build, and test" but its body only ran `npm install && npm run build` — so no assertions ever executed on push. Appends `&& npm test` to that step so the full `node:test` suite runs on every push across the existing node/OS matrix.

This is the root pattern that let the 3+ parent `Merge:` row bug ship in 1.6.3 without local catch — even with PR #22's new property suite, a regression in either suite would still green-light CI without this change.

## Test plan

- [x] Existing `npm test` passes locally (verified in PR #22)
- [ ] CI run on this branch executes tests and passes across the matrix

Closes #23