### PR TITLE
test: raise fast-check iteration count in CI runs

### DIFF
--- a/CHANGELOG.long.md
+++ b/CHANGELOG.long.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-14 merges; 13 releases
+15 merges; 13 releases
 
 
 
@@ -14,6 +14,68 @@ Published tags:
 
 <a href="#1__6__17">1.6.17</a>, <a href="#1__6__16">1.6.16</a>, <a href="#1__6__15">1.6.15</a>, <a href="#1__6__6">1.6.6</a>, <a href="#1__6__5">1.6.5</a>, <a href="#1__6__4">1.6.4</a>, <a href="#1__6__3">1.6.3</a>, <a href="#1__6__2">1.6.2</a>, <a href="#1__6__1">1.6.1</a>, <a href="#1__6__0">1.6.0</a>, <a href="#1__5__0">1.5.0</a>, <a href="#1__4__1">1.4.1</a>, <a href="#1__0__0">1.0.0</a>
 
+
+
+
+
+&nbsp;
+
+&nbsp;
+
+## [Untagged] - May 23, 2026 12:16:18 AM
+
+Commit [60ff29b9fef201263dd6373480f299fe18f0f83a](https://github.com/StoneCypher/better_git_changelog/commit/60ff29b9fef201263dd6373480f299fe18f0f83a)
+
+Author: `John Haugeland <stonecypher@gmail.com>`
+
+  * test: raise fast-check iteration count in CI runs
+  * Configure fast-check globally to use 1000 numRuns per property when
+process.env.CI is set, and the default 100 otherwise. GitHub Actions
+sets CI=true automatically; local invocations stay fast.
+  * Observed timing on this branch: ~670ms local (100 runs/prop) vs.
+~2.3s in CI mode (1000 runs/prop). Trade-off is well inside the slack
+budget of an existing CI job.
+  * Closes #25
+
+
+
+
+&nbsp;
+
+&nbsp;
+
+## [Untagged] - May 23, 2026 2:20:45 AM
+
+Commit [b6985f8169e6326fa524d79c84e0ed293a97280c](https://github.com/StoneCypher/better_git_changelog/commit/b6985f8169e6326fa524d79c84e0ed293a97280c)
+
+Author: `John Haugeland <stonecypher@gmail.com>`
+
+Merges [7c424bd, dfbe360]
+
+  * Merge pull request #28 from StoneCypher/ci_26-05-23_split-unit-property-tests_24
+  * ci: split test execution into unit and property steps
+
+
+
+
+&nbsp;
+
+&nbsp;
+
+## [Untagged] - May 23, 2026 12:13:03 AM
+
+Commit [dfbe3601b219cb5dafb825678999eb50a28b6aa6](https://github.com/StoneCypher/better_git_changelog/commit/dfbe3601b219cb5dafb825678999eb50a28b6aa6)
+
+Author: `John Haugeland <stonecypher@gmail.com>`
+
+  * ci: split test execution into unit and property steps
+  * Replace the bundled "npm install, build, and test" step with three
+distinct steps: install+build, then `npm run test:unit`, then
+`npm run test:property`. Each test suite now produces its own check
+entry in the GitHub PR UI and its own clearly-bounded log section, so
+a property-test shrink output doesn't get buried among unit assertions.
+  * Supersedes #23 / PR #27 (which added a single bundled `npm test`).
+  * Closes #24
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-14 merges; 13 releases; Changelogging the last 10 commits; Full changelog at [CHANGELOG.long.md](CHANGELOG.long.md)
+15 merges; 13 releases; Changelogging the last 10 commits; Full changelog at [CHANGELOG.long.md](CHANGELOG.long.md)
 
 
 
@@ -14,6 +14,68 @@ Published tags:
 
 <a href="#1__6__17">1.6.17</a>, <a href="#1__6__16">1.6.16</a>, <a href="#1__6__15">1.6.15</a>, <a href="#1__6__6">1.6.6</a>, <a href="#1__6__5">1.6.5</a>, <a href="#1__6__4">1.6.4</a>, <a href="#1__6__3">1.6.3</a>, <a href="#1__6__2">1.6.2</a>, <a href="#1__6__1">1.6.1</a>, <a href="#1__6__0">1.6.0</a>, <a href="#1__5__0">1.5.0</a>, <a href="#1__4__1">1.4.1</a>, <a href="#1__0__0">1.0.0</a>
 
+
+
+
+
+&nbsp;
+
+&nbsp;
+
+## [Untagged] - May 23, 2026 12:16:18 AM
+
+Commit [60ff29b9fef201263dd6373480f299fe18f0f83a](https://github.com/StoneCypher/better_git_changelog/commit/60ff29b9fef201263dd6373480f299fe18f0f83a)
+
+Author: `John Haugeland <stonecypher@gmail.com>`
+
+  * test: raise fast-check iteration count in CI runs
+  * Configure fast-check globally to use 1000 numRuns per property when
+process.env.CI is set, and the default 100 otherwise. GitHub Actions
+sets CI=true automatically; local invocations stay fast.
+  * Observed timing on this branch: ~670ms local (100 runs/prop) vs.
+~2.3s in CI mode (1000 runs/prop). Trade-off is well inside the slack
+budget of an existing CI job.
+  * Closes #25
+
+
+
+
+&nbsp;
+
+&nbsp;
+
+## [Untagged] - May 23, 2026 2:20:45 AM
+
+Commit [b6985f8169e6326fa524d79c84e0ed293a97280c](https://github.com/StoneCypher/better_git_changelog/commit/b6985f8169e6326fa524d79c84e0ed293a97280c)
+
+Author: `John Haugeland <stonecypher@gmail.com>`
+
+Merges [7c424bd, dfbe360]
+
+  * Merge pull request #28 from StoneCypher/ci_26-05-23_split-unit-property-tests_24
+  * ci: split test execution into unit and property steps
+
+
+
+
+&nbsp;
+
+&nbsp;
+
+## [Untagged] - May 23, 2026 12:13:03 AM
+
+Commit [dfbe3601b219cb5dafb825678999eb50a28b6aa6](https://github.com/StoneCypher/better_git_changelog/commit/dfbe3601b219cb5dafb825678999eb50a28b6aa6)
+
+Author: `John Haugeland <stonecypher@gmail.com>`
+
+  * ci: split test execution into unit and property steps
+  * Replace the bundled "npm install, build, and test" step with three
+distinct steps: install+build, then `npm run test:unit`, then
+`npm run test:property`. Each test suite now produces its own check
+entry in the GitHub PR UI and its own clearly-bounded log section, so
+a property-test shrink output doesn't get buried among unit assertions.
+  * Supersedes #23 / PR #27 (which added a single bundled `npm test`).
+  * Closes #24
 
 
 
@@ -156,69 +218,3 @@ Author: `John Haugeland <stonecypher@gmail.com>`
 row provisioned the Node version it declared. Replace both references
 with the literal 24 so every row uses Node 24 regardless of the
 matrix entry's node-version field.
-
-
-
-
-&nbsp;
-
-&nbsp;
-
-## [Untagged] - May 23, 2026 12:16:18 AM
-
-Commit [39b77234b2a6083dfb5871e7aea5604a84e90b26](https://github.com/StoneCypher/better_git_changelog/commit/39b77234b2a6083dfb5871e7aea5604a84e90b26)
-
-Author: `John Haugeland <stonecypher@gmail.com>`
-
-  * test: raise fast-check iteration count in CI runs
-  * Configure fast-check globally to use 1000 numRuns per property when
-process.env.CI is set, and the default 100 otherwise. GitHub Actions
-sets CI=true automatically; local invocations stay fast.
-  * Observed timing on this branch: ~670ms local (100 runs/prop) vs.
-~2.3s in CI mode (1000 runs/prop). Trade-off is well inside the slack
-budget of an existing CI job.
-  * Closes #25
-
-
-
-
-&nbsp;
-
-&nbsp;
-
-## [Untagged] - May 23, 2026 12:16:18 AM
-
-Commit [d637482aa02c1758af558ccb431bf1cc844532b2](https://github.com/StoneCypher/better_git_changelog/commit/d637482aa02c1758af558ccb431bf1cc844532b2)
-
-Author: `John Haugeland <stonecypher@gmail.com>`
-
-  * test: raise fast-check iteration count in CI runs
-  * Configure fast-check globally to use 1000 numRuns per property when
-process.env.CI is set, and the default 100 otherwise. GitHub Actions
-sets CI=true automatically; local invocations stay fast.
-  * Observed timing on this branch: ~670ms local (100 runs/prop) vs.
-~2.3s in CI mode (1000 runs/prop). Trade-off is well inside the slack
-budget of an existing CI job.
-  * Closes #25
-
-
-
-
-&nbsp;
-
-&nbsp;
-
-## [Untagged] - May 23, 2026 12:13:03 AM
-
-Commit [1b25002dd1f7d5d6e444fbe6cdb898e9567fdc60](https://github.com/StoneCypher/better_git_changelog/commit/1b25002dd1f7d5d6e444fbe6cdb898e9567fdc60)
-
-Author: `John Haugeland <stonecypher@gmail.com>`
-
-  * ci: split test execution into unit and property steps
-  * Replace the bundled "npm install, build, and test" step with three
-distinct steps: install+build, then `npm run test:unit`, then
-`npm run test:property`. Each test suite now produces its own check
-entry in the GitHub PR UI and its own clearly-bounded log section, so
-a property-test shrink output doesn't get buried among unit assertions.
-  * Supersedes #23 / PR #27 (which added a single bundled `npm test`).
-  * Closes #24

--- a/src/js/test/property/parser.property.test.js
+++ b/src/js/test/property/parser.property.test.js
@@ -19,6 +19,17 @@ const { parse_rl } = require('../../index.js');
 
 
 
+// fast-check defaults to 100 runs per property — fast for local iteration,
+// thin for the kind of input-space exploration this suite exists to do. In
+// CI we have slack budget and want bugs that hide in 1-in-N input shapes to
+// fail more often than never. GitHub Actions sets process.env.CI to 'true'
+// automatically, so the higher count kicks in only when the suite runs there.
+fc.configureGlobal({
+  numRuns: process.env.CI ? 1000 : 100
+});
+
+
+
 // ---------------------------------------------------------------------------
 // Generators
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Configure fast-check globally to use 1000 `numRuns` per property when `process.env.CI` is set, and the default 100 otherwise. GitHub Actions sets `CI=true` automatically; local invocations stay fast.

The 10x exploration scales the input space the suite covers on every push without touching local iteration speed. Observed timing on this branch:

| Mode  | Runs/property | Suite total |
|-------|---------------|-------------|
| Local | 100           | ~670ms      |
| CI    | 1000          | ~2.3s       |

The trade-off is well inside the slack budget of an existing CI job — even at 50x (5000 runs) the suite would finish in under a minute.

## Open questions left for follow-up

- Whether to also fix the random seed in CI for reproducible failures. Left random for now; if a flake appears we can pin.
- Whether to bump to 5000+ once we see real CI timing across the matrix. The 1000 number is a starting point, not a benchmark.

## Relationship to other PRs

- **Base branch is PR #28's branch** (`ci_26-05-23_split-unit-property-tests_24`), which itself stacks on PR #22. Merge order: #22 → #28 → this PR (#25). Once each merges to main, the next one's base auto-rebases.

## Test plan

- [x] `npm run test:property` passes locally (default 100 runs, ~670ms)
- [x] `CI=true npm run test:property` passes locally (1000 runs, ~2.3s)
- [ ] CI confirms the higher-run mode on the matrix

Closes #25