### PR TITLE
fix: accept short hashes longer than 7 chars in Merge: rows

### DIFF
--- a/CHANGELOG.long.md
+++ b/CHANGELOG.long.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-10 merges; 12 releases
+11 merges; 13 releases
 
 
 
@@ -12,8 +12,288 @@ All notable changes to this project will be documented in this file.
 
 Published tags:
 
-<a href="#1__6__16">1.6.16</a>, <a href="#1__6__15">1.6.15</a>, <a href="#1__6__6">1.6.6</a>, <a href="#1__6__5">1.6.5</a>, <a href="#1__6__4">1.6.4</a>, <a href="#1__6__3">1.6.3</a>, <a href="#1__6__2">1.6.2</a>, <a href="#1__6__1">1.6.1</a>, <a href="#1__6__0">1.6.0</a>, <a href="#1__5__0">1.5.0</a>, <a href="#1__4__1">1.4.1</a>, <a href="#1__0__0">1.0.0</a>
+<a href="#1__6__17">1.6.17</a>, <a href="#1__6__16">1.6.16</a>, <a href="#1__6__15">1.6.15</a>, <a href="#1__6__6">1.6.6</a>, <a href="#1__6__5">1.6.5</a>, <a href="#1__6__4">1.6.4</a>, <a href="#1__6__3">1.6.3</a>, <a href="#1__6__2">1.6.2</a>, <a href="#1__6__1">1.6.1</a>, <a href="#1__6__0">1.6.0</a>, <a href="#1__5__0">1.5.0</a>, <a href="#1__4__1">1.4.1</a>, <a href="#1__0__0">1.0.0</a>
 
+
+
+
+
+&nbsp;
+
+&nbsp;
+
+## [Untagged] - May 23, 2026 12:24:49 AM
+
+Commit [bfb13e576e848578d739cb54c9dd6973c0d2f0a3](https://github.com/StoneCypher/better_git_changelog/commit/bfb13e576e848578d739cb54c9dd6973c0d2f0a3)
+
+Author: `John Haugeland <stonecypher@gmail.com>`
+
+  * fix: accept short hashes longer than 7 chars in Merge: rows
+  * The PEG grammar's ShortHash production hardcoded exactly seven hex
+characters. Once a repository's object set crosses git's auto-abbrev
+threshold (typically mid-thousands of commits, shape-dependent), git
+log emits 8+ character short hashes and the parser dies at the 8th
+character with "expected newline". Reported against 1.6.16 with a
+b0eda7bf shape; users worked around it with core.abbrev=7.
+  * Widen ShortHash to `Hex Hex Hex Hex Hex*` — four mandatory hex
+characters (git's documented --abbrev minimum) plus zero-or-more
+additional. PEG's greedy match plus the existing space/newline
+terminator in MergeRow keeps it unambiguous in context. The
+regenerated reflog_parser.js is included.
+  * This is the second bug in the same MergeRow area; the first
+(3+ parents) was fixed in e23fbdc / 1.6.6. The property suite added
+in PR #22 is mis-scoped against this class of bug (generator
+hardcoded to seven chars, matching the parser) and will be addressed
+in a follow-up.
+  * Closes #30
+
+
+
+
+&nbsp;
+
+&nbsp;
+
+## [Untagged] - May 23, 2026 12:10:24 AM
+
+Commit [c4c09fa48ff7776de6999091a31c10d012a0323a](https://github.com/StoneCypher/better_git_changelog/commit/c4c09fa48ff7776de6999091a31c10d012a0323a)
+
+Author: `John Haugeland <stonecypher@gmail.com>`
+
+  * ci: run the test suite in CI
+  * The build step was named "npm install, build, and test" but its body
+only ran `npm install && npm run build`, so assertions never executed
+on push. This is the root pattern that let the 3+ parent Merge: row
+bug ship in 1.6.3 without local catch.
+  * Append `&& npm test` to the run line so the full node:test suite
+runs on every push across the existing node/OS matrix. The step
+name is now accurate.
+  * Closes #23
+
+
+
+
+&nbsp;
+
+&nbsp;
+
+## [Untagged] - May 23, 2026 12:10:24 AM
+
+Commit [57d7f49f02a9e614f5b50ae7a0211f0eee5f4ea7](https://github.com/StoneCypher/better_git_changelog/commit/57d7f49f02a9e614f5b50ae7a0211f0eee5f4ea7)
+
+Author: `John Haugeland <stonecypher@gmail.com>`
+
+  * ci: run the test suite in CI
+  * The build step was named "npm install, build, and test" but its body
+only ran `npm install && npm run build`, so assertions never executed
+on push. This is the root pattern that let the 3+ parent Merge: row
+bug ship in 1.6.3 without local catch.
+  * Append `&& npm test` to the run line so the full node:test suite
+runs on every push across the existing node/OS matrix. The step
+name is now accurate.
+  * Closes #23
+
+
+
+
+&nbsp;
+
+&nbsp;
+
+## [Untagged] - May 23, 2026 12:07:54 AM
+
+Commit [45fa5c87fd867f2451048ba2194689bcc896971c](https://github.com/StoneCypher/better_git_changelog/commit/45fa5c87fd867f2451048ba2194689bcc896971c)
+
+Author: `John Haugeland <stonecypher@gmail.com>`
+
+  * ci: pin setup-node to 24 across the matrix
+  * The setup-node step was reading matrix.node-version, so each matrix
+row provisioned the Node version it declared. Replace both references
+with the literal 24 so every row uses Node 24 regardless of the
+matrix entry's node-version field.
+
+
+
+
+&nbsp;
+
+&nbsp;
+
+## [Untagged] - May 23, 2026 12:07:54 AM
+
+Commit [ff0f0f332586563f21dd5d3868066eab10e5c244](https://github.com/StoneCypher/better_git_changelog/commit/ff0f0f332586563f21dd5d3868066eab10e5c244)
+
+Author: `John Haugeland <stonecypher@gmail.com>`
+
+  * ci: pin setup-node to 24 across the matrix
+  * The setup-node step was reading matrix.node-version, so each matrix
+row provisioned the Node version it declared. Replace both references
+with the literal 24 so every row uses Node 24 regardless of the
+matrix entry's node-version field.
+
+
+
+
+&nbsp;
+
+&nbsp;
+
+## [Untagged] - May 23, 2026 12:24:49 AM
+
+Commit [b74c349b9f6f989447376d2128e29f0ac5000c8c](https://github.com/StoneCypher/better_git_changelog/commit/b74c349b9f6f989447376d2128e29f0ac5000c8c)
+
+Author: `John Haugeland <stonecypher@gmail.com>`
+
+  * fix: accept short hashes longer than 7 chars in Merge: rows
+  * The PEG grammar's ShortHash production hardcoded exactly seven hex
+characters. Once a repository's object set crosses git's auto-abbrev
+threshold (typically mid-thousands of commits, shape-dependent), git
+log emits 8+ character short hashes and the parser dies at the 8th
+character with "expected newline". Reported against 1.6.16 with a
+b0eda7bf shape; users worked around it with core.abbrev=7.
+  * Widen ShortHash to `Hex Hex Hex Hex Hex*` — four mandatory hex
+characters (git's documented --abbrev minimum) plus zero-or-more
+additional. PEG's greedy match plus the existing space/newline
+terminator in MergeRow keeps it unambiguous in context. The
+regenerated reflog_parser.js is included.
+  * This is the second bug in the same MergeRow area; the first
+(3+ parents) was fixed in e23fbdc / 1.6.6. The property suite added
+in PR #22 is mis-scoped against this class of bug (generator
+hardcoded to seven chars, matching the parser) and will be addressed
+in a follow-up.
+  * Closes #30
+
+
+
+
+&nbsp;
+
+&nbsp;
+
+## [Untagged] - May 23, 2026 12:16:18 AM
+
+Commit [a9e089bd06969253f9e7a202a305566e2843b66c](https://github.com/StoneCypher/better_git_changelog/commit/a9e089bd06969253f9e7a202a305566e2843b66c)
+
+Author: `John Haugeland <stonecypher@gmail.com>`
+
+  * test: raise fast-check iteration count in CI runs
+  * Configure fast-check globally to use 1000 numRuns per property when
+process.env.CI is set, and the default 100 otherwise. GitHub Actions
+sets CI=true automatically; local invocations stay fast.
+  * Observed timing on this branch: ~670ms local (100 runs/prop) vs.
+~2.3s in CI mode (1000 runs/prop). Trade-off is well inside the slack
+budget of an existing CI job.
+  * Closes #25
+
+
+
+
+&nbsp;
+
+&nbsp;
+
+## [Untagged] - May 23, 2026 12:13:03 AM
+
+Commit [b3ab0a55cbdaed33c271f82106e0dbec2988fe5a](https://github.com/StoneCypher/better_git_changelog/commit/b3ab0a55cbdaed33c271f82106e0dbec2988fe5a)
+
+Author: `John Haugeland <stonecypher@gmail.com>`
+
+  * ci: split test execution into unit and property steps
+  * Replace the bundled "npm install, build, and test" step with three
+distinct steps: install+build, then `npm run test:unit`, then
+`npm run test:property`. Each test suite now produces its own check
+entry in the GitHub PR UI and its own clearly-bounded log section, so
+a property-test shrink output doesn't get buried among unit assertions.
+  * Supersedes #23 / PR #27 (which added a single bundled `npm test`).
+  * Closes #24
+
+
+
+
+&nbsp;
+
+&nbsp;
+
+## [Untagged] - May 23, 2026 12:10:24 AM
+
+Commit [153d3b542152b1daa162d213fce6363e25b8aa98](https://github.com/StoneCypher/better_git_changelog/commit/153d3b542152b1daa162d213fce6363e25b8aa98)
+
+Author: `John Haugeland <stonecypher@gmail.com>`
+
+  * ci: run the test suite in CI
+  * The build step was named "npm install, build, and test" but its body
+only ran `npm install && npm run build`, so assertions never executed
+on push. This is the root pattern that let the 3+ parent Merge: row
+bug ship in 1.6.3 without local catch.
+  * Append `&& npm test` to the run line so the full node:test suite
+runs on every push across the existing node/OS matrix. The step
+name is now accurate.
+  * Closes #23
+
+
+
+
+&nbsp;
+
+&nbsp;
+
+## [Untagged] - May 23, 2026 12:07:54 AM
+
+Commit [e01caaea01ad77d5188767355fb1eec8487bf9fa](https://github.com/StoneCypher/better_git_changelog/commit/e01caaea01ad77d5188767355fb1eec8487bf9fa)
+
+Author: `John Haugeland <stonecypher@gmail.com>`
+
+  * ci: pin setup-node to 24 across the matrix
+  * The setup-node step was reading matrix.node-version, so each matrix
+row provisioned the Node version it declared. Replace both references
+with the literal 24 so every row uses Node 24 regardless of the
+matrix entry's node-version field.
+
+
+
+
+&nbsp;
+
+&nbsp;
+
+<a name="1__6__17" />
+
+## [1.6.17] - May 22, 2026 6:40:43 PM
+
+Commit [2f14edb6f48740b76cc748f566dc8f73bc07c07c](https://github.com/StoneCypher/better_git_changelog/commit/2f14edb6f48740b76cc748f566dc8f73bc07c07c)
+
+Author: `John Haugeland <stonecypher@gmail.com>`
+
+Merges [5555714, 7838137]
+
+  * Merge pull request #22 from StoneCypher/test_26-05-22_property-based-parser
+  * test: add fast-check property suite for the reflog parser
+
+
+
+
+&nbsp;
+
+&nbsp;
+
+## [Untagged] - May 22, 2026 6:03:29 PM
+
+Commit [7838137b198632a8725fe220453579d55605b4a6](https://github.com/StoneCypher/better_git_changelog/commit/7838137b198632a8725fe220453579d55605b4a6)
+
+Author: `John Haugeland <stonecypher@gmail.com>`
+
+  * test: add fast-check property suite for the reflog parser
+  * Example-based tests over the captured fixture missed the 3+ parent
+Merge: row bug fixed in e23fbdc; the failure was reported by a
+downstream consumer rather than caught locally. The new suite
+generates plausible reflog inputs at runtime and asserts the parser
+preserves count, hash order, merge parents (including 2..12), author
+text, and finite timestamps, plus a smoke property that it never
+throws on any well-formed input.
+  * Also adds one explicit regression in parser.test.js mirroring the
+bug-report's exact 3-parent stash-with-untracked Merge: line, and
+splits the npm scripts into unit / property variants for both test
+and coverage so the two styles can be measured separately.
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-10 merges; 12 releases; Changelogging the last 10 commits; Full changelog at [CHANGELOG.long.md](CHANGELOG.long.md)
+11 merges; 13 releases; Changelogging the last 10 commits; Full changelog at [CHANGELOG.long.md](CHANGELOG.long.md)
 
 
 
@@ -12,7 +12,7 @@ All notable changes to this project will be documented in this file.
 
 Published tags:
 
-<a href="#1__6__16">1.6.16</a>, <a href="#1__6__15">1.6.15</a>, <a href="#1__6__6">1.6.6</a>, <a href="#1__6__5">1.6.5</a>, <a href="#1__6__4">1.6.4</a>, <a href="#1__6__3">1.6.3</a>, <a href="#1__6__2">1.6.2</a>, <a href="#1__6__1">1.6.1</a>, <a href="#1__6__0">1.6.0</a>, <a href="#1__5__0">1.5.0</a>, <a href="#1__4__1">1.4.1</a>, <a href="#1__0__0">1.0.0</a>
+<a href="#1__6__17">1.6.17</a>, <a href="#1__6__16">1.6.16</a>, <a href="#1__6__15">1.6.15</a>, <a href="#1__6__6">1.6.6</a>, <a href="#1__6__5">1.6.5</a>, <a href="#1__6__4">1.6.4</a>, <a href="#1__6__3">1.6.3</a>, <a href="#1__6__2">1.6.2</a>, <a href="#1__6__1">1.6.1</a>, <a href="#1__6__0">1.6.0</a>, <a href="#1__5__0">1.5.0</a>, <a href="#1__4__1">1.4.1</a>, <a href="#1__0__0">1.0.0</a>
 
 
 
@@ -22,16 +22,30 @@ Published tags:
 
 &nbsp;
 
-## [Untagged] - May 20, 2026 4:50:13 PM
+## [Untagged] - May 23, 2026 12:24:49 AM
 
-Commit [5555714d943d48f9a4afb51609f7aed4a4c92191](https://github.com/StoneCypher/better_git_changelog/commit/5555714d943d48f9a4afb51609f7aed4a4c92191)
+Commit [bfb13e576e848578d739cb54c9dd6973c0d2f0a3](https://github.com/StoneCypher/better_git_changelog/commit/bfb13e576e848578d739cb54c9dd6973c0d2f0a3)
 
 Author: `John Haugeland <stonecypher@gmail.com>`
 
-Merges [dad8713, 539ecbb]
-
-  * Merge pull request #21 from StoneCypher/feat_26-05-18_ship-type-declarations_20
-  * Ship verified TypeScript type declarations
+  * fix: accept short hashes longer than 7 chars in Merge: rows
+  * The PEG grammar's ShortHash production hardcoded exactly seven hex
+characters. Once a repository's object set crosses git's auto-abbrev
+threshold (typically mid-thousands of commits, shape-dependent), git
+log emits 8+ character short hashes and the parser dies at the 8th
+character with "expected newline". Reported against 1.6.16 with a
+b0eda7bf shape; users worked around it with core.abbrev=7.
+  * Widen ShortHash to `Hex Hex Hex Hex Hex*` — four mandatory hex
+characters (git's documented --abbrev minimum) plus zero-or-more
+additional. PEG's greedy match plus the existing space/newline
+terminator in MergeRow keeps it unambiguous in context. The
+regenerated reflog_parser.js is included.
+  * This is the second bug in the same MergeRow area; the first
+(3+ parents) was fixed in e23fbdc / 1.6.6. The property suite added
+in PR #22 is mis-scoped against this class of bug (generator
+hardcoded to seven chars, matching the parser) and will be addressed
+in a follow-up.
+  * Closes #30
 
 
 
@@ -40,14 +54,21 @@ Merges [dad8713, 539ecbb]
 
 &nbsp;
 
-## [Untagged] - May 20, 2026 4:45:08 PM
+## [Untagged] - May 23, 2026 12:10:24 AM
 
-Commit [539ecbb1f59b9bca371568bfa9c9cf14da41964a](https://github.com/StoneCypher/better_git_changelog/commit/539ecbb1f59b9bca371568bfa9c9cf14da41964a)
+Commit [c4c09fa48ff7776de6999091a31c10d012a0323a](https://github.com/StoneCypher/better_git_changelog/commit/c4c09fa48ff7776de6999091a31c10d012a0323a)
 
 Author: `John Haugeland <stonecypher@gmail.com>`
 
-  * ci: temporarily disable attw type-correctness gate
-  * The published @arethetypeswrong/cli@0.18.2 crashes with 'Cannot read properties of undefined (reading filename)' when invoked after 'npm install -g' in CI, on every matrix combo. The same version installed via 'npx' passes locally — so it appears to be a published-artifact / global-install bug, not our package's types. Disabling the gate to unblock builds. The .d.ts files are still generated and shipped; check-dts smoke test still gates the build; the check-types npm script is retained for manual local use against the linked attw fork.
+  * ci: run the test suite in CI
+  * The build step was named "npm install, build, and test" but its body
+only ran `npm install && npm run build`, so assertions never executed
+on push. This is the root pattern that let the 3+ parent Merge: row
+bug ship in 1.6.3 without local catch.
+  * Append `&& npm test` to the run line so the full node:test suite
+runs on every push across the existing node/OS matrix. The step
+name is now accurate.
+  * Closes #23
 
 
 
@@ -56,14 +77,21 @@ Author: `John Haugeland <stonecypher@gmail.com>`
 
 &nbsp;
 
-## [Untagged] - May 20, 2026 4:00:47 PM
+## [Untagged] - May 23, 2026 12:10:24 AM
 
-Commit [a6aee18330c2b03903a7448400ff6f11bc268ce2](https://github.com/StoneCypher/better_git_changelog/commit/a6aee18330c2b03903a7448400ff6f11bc268ce2)
+Commit [57d7f49f02a9e614f5b50ae7a0211f0eee5f4ea7](https://github.com/StoneCypher/better_git_changelog/commit/57d7f49f02a9e614f5b50ae7a0211f0eee5f4ea7)
 
 Author: `John Haugeland <stonecypher@gmail.com>`
 
-  * ci: pin attw to 0.18.2 (the published @latest crashes despite same version)
-  * @arethetypeswrong/cli@latest currently resolves to 0.18.2 but the install of the @latest tag crashes with 'Cannot read properties of undefined (reading filename)' on every matrix combo. Invoking @0.18.2 explicitly works (verified locally). Pin to that exact version until the published @latest is stable.
+  * ci: run the test suite in CI
+  * The build step was named "npm install, build, and test" but its body
+only ran `npm install && npm run build`, so assertions never executed
+on push. This is the root pattern that let the 3+ parent Merge: row
+bug ship in 1.6.3 without local catch.
+  * Append `&& npm test` to the run line so the full node:test suite
+runs on every push across the existing node/OS matrix. The step
+name is now accurate.
+  * Closes #23
 
 
 
@@ -72,14 +100,17 @@ Author: `John Haugeland <stonecypher@gmail.com>`
 
 &nbsp;
 
-## [Untagged] - May 18, 2026 10:50:04 PM
+## [Untagged] - May 23, 2026 12:07:54 AM
 
-Commit [4704025482be3c61e6a28e02bdc49005eb491a1e](https://github.com/StoneCypher/better_git_changelog/commit/4704025482be3c61e6a28e02bdc49005eb491a1e)
+Commit [45fa5c87fd867f2451048ba2194689bcc896971c](https://github.com/StoneCypher/better_git_changelog/commit/45fa5c87fd867f2451048ba2194689bcc896971c)
 
 Author: `John Haugeland <stonecypher@gmail.com>`
 
-  * test: add a TypeScript smoke test for the published declarations
-  * type-tests/smoke.ts imports the package by name (through the exports map, as a consumer would) and asserts the shipped .d.ts signatures, with @ts-expect-error blocks guarding against silent regression to any. Wired into build via the check-dts script.
+  * ci: pin setup-node to 24 across the matrix
+  * The setup-node step was reading matrix.node-version, so each matrix
+row provisioned the Node version it declared. Replace both references
+with the literal 24 so every row uses Node 24 regardless of the
+matrix entry's node-version field.
 
 
 
@@ -88,14 +119,17 @@ Author: `John Haugeland <stonecypher@gmail.com>`
 
 &nbsp;
 
-## [Untagged] - May 18, 2026 10:44:30 PM
+## [Untagged] - May 23, 2026 12:07:54 AM
 
-Commit [d53f342e6bec67b1156f92895b2b753f1df19fb9](https://github.com/StoneCypher/better_git_changelog/commit/d53f342e6bec67b1156f92895b2b753f1df19fb9)
+Commit [ff0f0f332586563f21dd5d3868066eab10e5c244](https://github.com/StoneCypher/better_git_changelog/commit/ff0f0f332586563f21dd5d3868066eab10e5c244)
 
 Author: `John Haugeland <stonecypher@gmail.com>`
 
-  * ci: provision attw and build before publishing
-  * The build job installs the published @arethetypeswrong/cli so build's new attw type-check can run. The release job now installs deps and runs the build before npm publish, so the generated dist/types declarations are present in the published tarball (the job previously published from a raw checkout).
+  * ci: pin setup-node to 24 across the matrix
+  * The setup-node step was reading matrix.node-version, so each matrix
+row provisioned the Node version it declared. Replace both references
+with the literal 24 so every row uses Node 24 regardless of the
+matrix entry's node-version field.
 
 
 
@@ -104,14 +138,30 @@ Author: `John Haugeland <stonecypher@gmail.com>`
 
 &nbsp;
 
-## [Untagged] - May 18, 2026 10:41:30 PM
+## [Untagged] - May 23, 2026 12:24:49 AM
 
-Commit [2c338a7bc9b0fcc0a74735422faa572181fbcb42](https://github.com/StoneCypher/better_git_changelog/commit/2c338a7bc9b0fcc0a74735422faa572181fbcb42)
+Commit [b74c349b9f6f989447376d2128e29f0ac5000c8c](https://github.com/StoneCypher/better_git_changelog/commit/b74c349b9f6f989447376d2128e29f0ac5000c8c)
 
 Author: `John Haugeland <stonecypher@gmail.com>`
 
-  * build: ship type declarations and trim the published package
-  * Adds types/exports pointing at the generated declarations, an engines field matching the documented Node requirement, and a files allowlist so the tarball no longer publishes test fixtures or grammar sources. build now generates declarations and gates on an attw check.
+  * fix: accept short hashes longer than 7 chars in Merge: rows
+  * The PEG grammar's ShortHash production hardcoded exactly seven hex
+characters. Once a repository's object set crosses git's auto-abbrev
+threshold (typically mid-thousands of commits, shape-dependent), git
+log emits 8+ character short hashes and the parser dies at the 8th
+character with "expected newline". Reported against 1.6.16 with a
+b0eda7bf shape; users worked around it with core.abbrev=7.
+  * Widen ShortHash to `Hex Hex Hex Hex Hex*` — four mandatory hex
+characters (git's documented --abbrev minimum) plus zero-or-more
+additional. PEG's greedy match plus the existing space/newline
+terminator in MergeRow keeps it unambiguous in context. The
+regenerated reflog_parser.js is included.
+  * This is the second bug in the same MergeRow area; the first
+(3+ parents) was fixed in e23fbdc / 1.6.6. The property suite added
+in PR #22 is mis-scoped against this class of bug (generator
+hardcoded to seven chars, matching the parser) and will be addressed
+in a follow-up.
+  * Closes #30
 
 
 
@@ -120,14 +170,20 @@ Author: `John Haugeland <stonecypher@gmail.com>`
 
 &nbsp;
 
-## [Untagged] - May 18, 2026 10:39:10 PM
+## [Untagged] - May 23, 2026 12:16:18 AM
 
-Commit [c58746d55e1a3badc058fa005c9658bbf3acd7af](https://github.com/StoneCypher/better_git_changelog/commit/c58746d55e1a3badc058fa005c9658bbf3acd7af)
+Commit [a9e089bd06969253f9e7a202a305566e2843b66c](https://github.com/StoneCypher/better_git_changelog/commit/a9e089bd06969253f9e7a202a305566e2843b66c)
 
 Author: `John Haugeland <stonecypher@gmail.com>`
 
-  * build: add declaration-emit tsconfig and PEG parser typings
-  * tsconfig.json emits .d.ts from the JSDoc-annotated CommonJS sources into dist/types. reflog_parser.d.ts types the generated PEG parser; parse_rl is given an explicit @type so the emitted index.d.ts is self-contained.
+  * test: raise fast-check iteration count in CI runs
+  * Configure fast-check globally to use 1000 numRuns per property when
+process.env.CI is set, and the default 100 otherwise. GitHub Actions
+sets CI=true automatically; local invocations stay fast.
+  * Observed timing on this branch: ~670ms local (100 runs/prop) vs.
+~2.3s in CI mode (1000 runs/prop). Trade-off is well inside the slack
+budget of an existing CI job.
+  * Closes #25
 
 
 
@@ -136,14 +192,20 @@ Author: `John Haugeland <stonecypher@gmail.com>`
 
 &nbsp;
 
-## [Untagged] - May 18, 2026 6:07:47 PM
+## [Untagged] - May 23, 2026 12:13:03 AM
 
-Commit [566c1a4227188598d6905ecf4c5ae1b852761353](https://github.com/StoneCypher/better_git_changelog/commit/566c1a4227188598d6905ecf4c5ae1b852761353)
+Commit [b3ab0a55cbdaed33c271f82106e0dbec2988fe5a](https://github.com/StoneCypher/better_git_changelog/commit/b3ab0a55cbdaed33c271f82106e0dbec2988fe5a)
 
 Author: `John Haugeland <stonecypher@gmail.com>`
 
-  * docs: add typed JSDoc and shared typedefs to index.js and i18n.js
-  * Completes the JSDoc type surface so tsc can emit accurate .d.ts files. Introduces ReflogEntry, ScanResult, ScanAllResult, and Translator typedefs and types every exported function's params and returns.
+  * ci: split test execution into unit and property steps
+  * Replace the bundled "npm install, build, and test" step with three
+distinct steps: install+build, then `npm run test:unit`, then
+`npm run test:property`. Each test suite now produces its own check
+entry in the GitHub PR UI and its own clearly-bounded log section, so
+a property-test shrink output doesn't get buried among unit assertions.
+  * Supersedes #23 / PR #27 (which added a single bundled `npm test`).
+  * Closes #24
 
 
 
@@ -152,16 +214,21 @@ Author: `John Haugeland <stonecypher@gmail.com>`
 
 &nbsp;
 
-## [Untagged] - May 18, 2026 3:57:36 PM
+## [Untagged] - May 23, 2026 12:10:24 AM
 
-Commit [dad87139fece628a2c19ade36659f0a04a68556d](https://github.com/StoneCypher/better_git_changelog/commit/dad87139fece628a2c19ade36659f0a04a68556d)
+Commit [153d3b542152b1daa162d213fce6363e25b8aa98](https://github.com/StoneCypher/better_git_changelog/commit/153d3b542152b1daa162d213fce6363e25b8aa98)
 
 Author: `John Haugeland <stonecypher@gmail.com>`
 
-Merges [8031880, 4f34e23]
-
-  * Merge pull request #19 from StoneCypher/refactor_26-05-18_extract-cli-core
-  * refactor: extract testable CLI logic into cli_core.js for coverage
+  * ci: run the test suite in CI
+  * The build step was named "npm install, build, and test" but its body
+only ran `npm install && npm run build`, so assertions never executed
+on push. This is the root pattern that let the 3+ parent Merge: row
+bug ship in 1.6.3 without local catch.
+  * Append `&& npm test` to the run line so the full node:test suite
+runs on every push across the existing node/OS matrix. The step
+name is now accurate.
+  * Closes #23
 
 
 
@@ -170,11 +237,14 @@ Merges [8031880, 4f34e23]
 
 &nbsp;
 
-## [Untagged] - May 18, 2026 3:51:30 PM
+## [Untagged] - May 23, 2026 12:07:54 AM
 
-Commit [4f34e23888e539fe67add3305fe223bd43a25e0e](https://github.com/StoneCypher/better_git_changelog/commit/4f34e23888e539fe67add3305fe223bd43a25e0e)
+Commit [e01caaea01ad77d5188767355fb1eec8487bf9fa](https://github.com/StoneCypher/better_git_changelog/commit/e01caaea01ad77d5188767355fb1eec8487bf9fa)
 
 Author: `John Haugeland <stonecypher@gmail.com>`
 
-  * refactor: extract testable CLI logic into cli_core.js
-  * cli.js was a procedural entry-point script with no testable surface — its argv pre-scan, the -S validator, and the long/short/both decision logic were not reachable by the coverage instrumentation. Those three pure functions now live in cli_core.js with full unit tests (cli_core.test.js, 100% covered); cli.js requires them. No behavior change — the build's self-run confirms the CLI still works. Overall line coverage rises 93.0% to 94.1%, branch 85.0% to 88.9%.
+  * ci: pin setup-node to 24 across the matrix
+  * The setup-node step was reading matrix.node-version, so each matrix
+row provisioned the Node version it declared. Replace both references
+with the literal 24 so every row uses Node 24 regardless of the
+matrix entry's node-version field.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "better_git_changelog",
-  "version": "1.6.17",
+  "version": "1.6.18",
   "description": "Make a changelog from git commits, tags, and releases",
   "main": "src/js/index.js",
   "types": "./dist/types/index.d.ts",

--- a/src/js/reflog_parser.js
+++ b/src/js/reflog_parser.js
@@ -593,7 +593,7 @@ function peg$parse(input, options) {
   }
 
   function peg$parseShortHash() {
-    var s0, s1, s2, s3, s4, s5, s6, s7;
+    var s0, s1, s2, s3, s4, s5, s6;
 
     s0 = peg$currPos;
     s1 = peg$parseHex();
@@ -604,23 +604,16 @@ function peg$parse(input, options) {
         if (s3 !== peg$FAILED) {
           s4 = peg$parseHex();
           if (s4 !== peg$FAILED) {
-            s5 = peg$parseHex();
-            if (s5 !== peg$FAILED) {
+            s5 = [];
+            s6 = peg$parseHex();
+            while (s6 !== peg$FAILED) {
+              s5.push(s6);
               s6 = peg$parseHex();
-              if (s6 !== peg$FAILED) {
-                s7 = peg$parseHex();
-                if (s7 !== peg$FAILED) {
-                  peg$savedPos = s0;
-                  s1 = peg$c2();
-                  s0 = s1;
-                } else {
-                  peg$currPos = s0;
-                  s0 = peg$FAILED;
-                }
-              } else {
-                peg$currPos = s0;
-                s0 = peg$FAILED;
-              }
+            }
+            if (s5 !== peg$FAILED) {
+              peg$savedPos = s0;
+              s1 = peg$c2();
+              s0 = s1;
             } else {
               peg$currPos = s0;
               s0 = peg$FAILED;

--- a/src/js/test/parser.test.js
+++ b/src/js/test/parser.test.js
@@ -79,3 +79,39 @@ test('parse_rl handles a 3-parent stash-with-untracked commit (bug-report shape)
   assert.strictEqual(parsed.length, 1);
   assert.deepStrictEqual(parsed[0].merge, ['232e461', 'beef2bb', 'e979fe1']);
 });
+
+// Regression for issue #30 (reported 2026-05-23 against 1.6.16): git's
+// auto-abbrev grows the short-hash length past 7 once a repository's
+// object set requires more characters for unique-prefix disambiguation.
+// The pre-fix ShortHash production accepted exactly 7 hex chars and
+// threw on the 8th. Grammar widened to `Hex Hex Hex Hex Hex*` (4+).
+test('parse_rl handles short hashes longer than 7 chars (auto-abbrev grew)', () => {
+  const widened =
+    'commit 2222222222222222222222222222222222222222\n' +
+    'Merge: b0eda7bf c1f2e3d4\n' +
+    'Author: A <a@example.com>\n' +
+    'Date:   Sat May 23 09:00:00 2026 -0700\n' +
+    '\n' +
+    '    merge with 8-char short hashes\n' +
+    '\n';
+  const parsed = parse_rl(widened);
+  assert.strictEqual(parsed.length, 1);
+  assert.deepStrictEqual(parsed[0].merge, ['b0eda7bf', 'c1f2e3d4']);
+});
+
+// Cover the documented minimum (--abbrev=4) and a longer auto-abbrev value,
+// to lock the new range explicitly rather than leaving "7 vs 8" as the only
+// known boundary.
+test('parse_rl handles short hashes from 4 to 12 characters', () => {
+  const sample =
+    'commit 3333333333333333333333333333333333333333\n' +
+    'Merge: abcd 12345 abcdef0 0123456789ab\n' +
+    'Author: A <a@example.com>\n' +
+    'Date:   Sat May 23 09:00:00 2026 -0700\n' +
+    '\n' +
+    '    mixed short-hash lengths\n' +
+    '\n';
+  const parsed = parse_rl(sample);
+  assert.strictEqual(parsed.length, 1);
+  assert.deepStrictEqual(parsed[0].merge, ['abcd', '12345', 'abcdef0', '0123456789ab']);
+});

--- a/src/peg/reflog_parser.peg
+++ b/src/peg/reflog_parser.peg
@@ -10,7 +10,7 @@ Hash
     Hex Hex Hex Hex Hex Hex Hex Hex Hex Hex Hex Hex Hex Hex Hex Hex Hex Hex Hex Hex { return text(); }
 
 ShortHash
-  = Hex Hex Hex Hex Hex Hex Hex { return text(); }
+  = Hex Hex Hex Hex Hex* { return text(); }
 
 CommitRow
   = 'commit ' hash:Hash '\n' { return hash; }


### PR DESCRIPTION
## Summary

The PEG grammar's `ShortHash` production at `src/peg/reflog_parser.peg:12-13` hardcoded exactly seven hex characters. Once a repository's object set crosses git's auto-abbrev threshold (typically mid-thousands of commits, shape-dependent), `git log` emits 8+ character short hashes and the parser dies at the 8th character with `Expected "\n" but X found`. Reported on 2026-05-23 against 1.6.16, downstream consumer hit it with a `b0eda7bf` shape and worked around via `core.abbrev=7`.

## Fix

Widen `ShortHash` from `Hex Hex Hex Hex Hex Hex Hex` to `Hex Hex Hex Hex Hex*` — four mandatory hex characters (git's documented `--abbrev` minimum) plus zero-or-more additional. PEG's greedy match plus the existing space/newline terminator in `MergeRow` keeps it unambiguous in context.

The regenerated `src/js/reflog_parser.js` is included in the same commit so the published package matches the grammar.

## Tests

Two new example-based regressions in `parser.test.js`:

1. **The reported shape:** `Merge: b0eda7bf c1f2e3d4` (two 8-char parents) — the exact failure mode from the bug report.
2. **A mixed-length sample:** `Merge: abcd 12345 abcdef0 0123456789ab` (4 / 5 / 7 / 12 chars) — locks the new range explicitly so the boundary isn't just "7 vs 8."

## Known follow-up

The property suite added in PR #22 hardcoded its `shortHash` generator to 7 characters, *matching the parser's restriction*. That makes its round-trip properties tautological against this class of bug — the suite would not have caught the 8-char failure. A follow-up issue will widen the generator (and document the methodology lesson). PR #22's existing tests will pass against this widened grammar without modification.

## Version

Bumped 1.6.16 → 1.6.17. May conflict with PR #22 (also bumps to 1.6.17); whichever lands first wins, the other rebases to 1.6.18.

## Test plan

- [x] `npm test` passes (71/71, including the two new regressions)
- [x] `npm run build` passes end-to-end (clean → peg → check-locales → tsc → check-dts → self)
- [x] No IDE diagnostics on touched files
- [ ] CI run confirms parity across the matrix

Closes #30