### PR TITLE
test: widen property-suite shortHash generator to git's real range

### DIFF
--- a/CHANGELOG.long.md
+++ b/CHANGELOG.long.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-15 merges; 13 releases
+16 merges; 13 releases
 
 
 
@@ -14,6 +14,46 @@ Published tags:
 
 <a href="#1__6__17">1.6.17</a>, <a href="#1__6__16">1.6.16</a>, <a href="#1__6__15">1.6.15</a>, <a href="#1__6__6">1.6.6</a>, <a href="#1__6__5">1.6.5</a>, <a href="#1__6__4">1.6.4</a>, <a href="#1__6__3">1.6.3</a>, <a href="#1__6__2">1.6.2</a>, <a href="#1__6__1">1.6.1</a>, <a href="#1__6__0">1.6.0</a>, <a href="#1__5__0">1.5.0</a>, <a href="#1__4__1">1.4.1</a>, <a href="#1__0__0">1.0.0</a>
 
+
+
+
+
+&nbsp;
+
+&nbsp;
+
+## [Untagged] - May 23, 2026 2:23:59 AM
+
+Commit [87635e1b7aac14e22505fe68c269c91fdf369d23](https://github.com/StoneCypher/better_git_changelog/commit/87635e1b7aac14e22505fe68c269c91fdf369d23)
+
+Author: `John Haugeland <stonecypher@gmail.com>`
+
+Merges [b6985f8, ed8b265]
+
+  * Merge pull request #29 from StoneCypher/test_26-05-23_property-test-numruns_25
+  * test: raise fast-check iteration count in CI runs
+
+
+
+
+&nbsp;
+
+&nbsp;
+
+## [Untagged] - May 23, 2026 12:16:18 AM
+
+Commit [ed8b2658418c2c43962d768a9416a4dbd33a135b](https://github.com/StoneCypher/better_git_changelog/commit/ed8b2658418c2c43962d768a9416a4dbd33a135b)
+
+Author: `John Haugeland <stonecypher@gmail.com>`
+
+  * test: raise fast-check iteration count in CI runs
+  * Configure fast-check globally to use 1000 numRuns per property when
+process.env.CI is set, and the default 100 otherwise. GitHub Actions
+sets CI=true automatically; local invocations stay fast.
+  * Observed timing on this branch: ~670ms local (100 runs/prop) vs.
+~2.3s in CI mode (1000 runs/prop). Trade-off is well inside the slack
+budget of an existing CI job.
+  * Closes #25
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-15 merges; 13 releases; Changelogging the last 10 commits; Full changelog at [CHANGELOG.long.md](CHANGELOG.long.md)
+16 merges; 13 releases; Changelogging the last 10 commits; Full changelog at [CHANGELOG.long.md](CHANGELOG.long.md)
 
 
 
@@ -14,6 +14,46 @@ Published tags:
 
 <a href="#1__6__17">1.6.17</a>, <a href="#1__6__16">1.6.16</a>, <a href="#1__6__15">1.6.15</a>, <a href="#1__6__6">1.6.6</a>, <a href="#1__6__5">1.6.5</a>, <a href="#1__6__4">1.6.4</a>, <a href="#1__6__3">1.6.3</a>, <a href="#1__6__2">1.6.2</a>, <a href="#1__6__1">1.6.1</a>, <a href="#1__6__0">1.6.0</a>, <a href="#1__5__0">1.5.0</a>, <a href="#1__4__1">1.4.1</a>, <a href="#1__0__0">1.0.0</a>
 
+
+
+
+
+&nbsp;
+
+&nbsp;
+
+## [Untagged] - May 23, 2026 2:23:59 AM
+
+Commit [87635e1b7aac14e22505fe68c269c91fdf369d23](https://github.com/StoneCypher/better_git_changelog/commit/87635e1b7aac14e22505fe68c269c91fdf369d23)
+
+Author: `John Haugeland <stonecypher@gmail.com>`
+
+Merges [b6985f8, ed8b265]
+
+  * Merge pull request #29 from StoneCypher/test_26-05-23_property-test-numruns_25
+  * test: raise fast-check iteration count in CI runs
+
+
+
+
+&nbsp;
+
+&nbsp;
+
+## [Untagged] - May 23, 2026 12:16:18 AM
+
+Commit [ed8b2658418c2c43962d768a9416a4dbd33a135b](https://github.com/StoneCypher/better_git_changelog/commit/ed8b2658418c2c43962d768a9416a4dbd33a135b)
+
+Author: `John Haugeland <stonecypher@gmail.com>`
+
+  * test: raise fast-check iteration count in CI runs
+  * Configure fast-check globally to use 1000 numRuns per property when
+process.env.CI is set, and the default 100 otherwise. GitHub Actions
+sets CI=true automatically; local invocations stay fast.
+  * Observed timing on this branch: ~670ms local (100 runs/prop) vs.
+~2.3s in CI mode (1000 runs/prop). Trade-off is well inside the slack
+budget of an existing CI job.
+  * Closes #25
 
 
 
@@ -180,41 +220,3 @@ Merges [94d66c7, 42fd16a]
 
   * Merge pull request #26 from StoneCypher/ci_26-05-23_pin-node-24
   * ci: pin setup-node to 24 across the matrix
-
-
-
-
-&nbsp;
-
-&nbsp;
-
-## [Untagged] - May 23, 2026 12:07:54 AM
-
-Commit [42fd16a2b374ba8e81447e5b3c476039b328b8a8](https://github.com/StoneCypher/better_git_changelog/commit/42fd16a2b374ba8e81447e5b3c476039b328b8a8)
-
-Author: `John Haugeland <stonecypher@gmail.com>`
-
-  * ci: pin setup-node to 24 across the matrix
-  * The setup-node step was reading matrix.node-version, so each matrix
-row provisioned the Node version it declared. Replace both references
-with the literal 24 so every row uses Node 24 regardless of the
-matrix entry's node-version field.
-
-
-
-
-&nbsp;
-
-&nbsp;
-
-## [Untagged] - May 23, 2026 12:07:54 AM
-
-Commit [b20d6dbf61e1dad9bdc7f5ab419a10cc26af485c](https://github.com/StoneCypher/better_git_changelog/commit/b20d6dbf61e1dad9bdc7f5ab419a10cc26af485c)
-
-Author: `John Haugeland <stonecypher@gmail.com>`
-
-  * ci: pin setup-node to 24 across the matrix
-  * The setup-node step was reading matrix.node-version, so each matrix
-row provisioned the Node version it declared. Replace both references
-with the literal 24 so every row uses Node 24 regardless of the
-matrix entry's node-version field.

--- a/src/js/test/property/parser.property.test.js
+++ b/src/js/test/property/parser.property.test.js
@@ -15,6 +15,18 @@ const { parse_rl } = require('../../index.js');
  * the canonical proof it does not. These tests instead generate plausible
  * reflog inputs at runtime and assert structural invariants that must hold
  * for every well-formed input the parser is expected to accept.
+ *
+ * Generator scoping note (issue #32, May 2026):
+ * The generators below reflect git's *real output range* — not the parser's
+ * current accepted range. This distinction matters: when an earlier revision
+ * of this file coupled the `shortHash` generator to the parser's 7-char
+ * hardcode, the round-trip properties became tautological and missed the
+ * exact bug they were written to catch (the parser failed on 8-char short
+ * hashes from auto-abbrev; the generator agreed with the parser so the
+ * property never produced a counter-example). If you tighten a generator
+ * to match the implementation, the property tests stop finding bugs in
+ * the implementation. Generators should track the contract of the input
+ * source (here: what `git log --reflog` actually emits).
  */
 
 
@@ -39,7 +51,11 @@ const hexChar = fc.constantFrom(
   '0','1','2','3','4','5','6','7','8','9','a','b','c','d','e','f'
 );
 
-const shortHash = fc.string({ unit: hexChar, minLength: 7,  maxLength: 7  });
+// git's --abbrev minimum is 4; auto-abbrev grows to 7+ for typical repos and
+// 8, 9, 10+ for large ones as needed for unique-prefix disambiguation. The
+// upper bound of 12 covers very large repos with room to spare without
+// risking collision with `fullHash` (40 chars) in unrelated grammar contexts.
+const shortHash = fc.string({ unit: hexChar, minLength:  4, maxLength: 12 });
 const fullHash  = fc.string({ unit: hexChar, minLength: 40, maxLength: 40 });
 
 // Any single-line string. Production `git log` is LF-only; the fixture


### PR DESCRIPTION
## Summary

The property suite's `shortHash` generator was hardcoded to 7 characters, matching what the parser accepted at the time of PR #22. That made the round-trip properties tautological — every "the parser preserves the parent list" round-trip succeeded because both sides agreed on 7, even when reality (`git log` auto-abbrev) was emitting 8+.

The 8-char auto-abbrev bug (#30, fixed in #31) is the canonical proof: it was exactly the class of bug the property suite was added to catch, and the suite did not catch it.

## Fix

Widen `shortHash` from `{minLength: 7, maxLength: 7}` to `{minLength: 4, maxLength: 12}` — git's documented `--abbrev` minimum through a comfortable upper bound for large-repo auto-abbrev. Now if the grammar ever re-narrows, the property tests fail immediately because the generator still produces inputs that *should* parse.

Adds a header comment documenting the methodology lesson for future contributors:

> Generators should track the contract of the input source (what `git log --reflog` actually emits), not the implementation's accepted range. If you tighten a generator to match the implementation, the property tests stop finding bugs in the implementation.

## Test plan

- [x] `npm run test:property` passes locally (8/8, default 100 runs/property)
- [x] `npm run build` passes end-to-end
- [x] No IDE diagnostics
- [ ] CI confirms with 1000 runs/property

Closes #32