### PR TITLE
docs(readme): add TOC, TypeScript, exports table, and Development sections

### DIFF
--- a/CHANGELOG.long.md
+++ b/CHANGELOG.long.md
@@ -22,6 +22,31 @@ Published tags:
 
 &nbsp;
 
+## [Untagged] - May 27, 2026 12:07:31 AM
+
+Commit [9fbe24af2eaea6cf93b8bdb06e40e336e6928c6f](https://github.com/StoneCypher/better_git_changelog/commit/9fbe24af2eaea6cf93b8bdb06e40e336e6928c6f)
+
+Author: `John Haugeland <stonecypher@gmail.com>`
+
+  * chore(release): 1.6.19
+  * Versions 1.6.17 and 1.6.18 reached GitHub (tag + release) but never
+landed on npm; latest published is still 1.6.16. The release job
+pushes the git tag before it attempts `npm publish`, so when publish
+failed the tag was already on the remote and the "tag exists" gate
+short-circuited every subsequent run. Bumping past 1.6.18 gives the
+workflow a fresh version the gate has not seen, so it will attempt
+to publish 1.6.19 (succeeds once a Trusted Publisher is registered
+for the package on npmjs.com).
+  * Regenerates CHANGELOG.md and CHANGELOG.long.md from the build; no
+source changes.
+
+
+
+
+&nbsp;
+
+&nbsp;
+
 ## [Untagged] - May 23, 2026 2:27:03 AM
 
 Commit [c198ba682da2ecaa8fa448efdddbe9a9e9d5beed](https://github.com/StoneCypher/better_git_changelog/commit/c198ba682da2ecaa8fa448efdddbe9a9e9d5beed)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,31 @@ Published tags:
 
 &nbsp;
 
+## [Untagged] - May 27, 2026 12:07:31 AM
+
+Commit [9fbe24af2eaea6cf93b8bdb06e40e336e6928c6f](https://github.com/StoneCypher/better_git_changelog/commit/9fbe24af2eaea6cf93b8bdb06e40e336e6928c6f)
+
+Author: `John Haugeland <stonecypher@gmail.com>`
+
+  * chore(release): 1.6.19
+  * Versions 1.6.17 and 1.6.18 reached GitHub (tag + release) but never
+landed on npm; latest published is still 1.6.16. The release job
+pushes the git tag before it attempts `npm publish`, so when publish
+failed the tag was already on the remote and the "tag exists" gate
+short-circuited every subsequent run. Bumping past 1.6.18 gives the
+workflow a fresh version the gate has not seen, so it will attempt
+to publish 1.6.19 (succeeds once a Trusted Publisher is registered
+for the package on npmjs.com).
+  * Regenerates CHANGELOG.md and CHANGELOG.long.md from the build; no
+source changes.
+
+
+
+
+&nbsp;
+
+&nbsp;
+
 ## [Untagged] - May 23, 2026 2:27:03 AM
 
 Commit [c198ba682da2ecaa8fa448efdddbe9a9e9d5beed](https://github.com/StoneCypher/better_git_changelog/commit/c198ba682da2ecaa8fa448efdddbe9a9e9d5beed)
@@ -203,26 +228,3 @@ Merges [a208c36, 7eeaf14]
 
   * Merge pull request #27 from StoneCypher/ci_26-05-22_npm-test-in-ci_23
   * ci: run the test suite in CI
-
-
-
-
-&nbsp;
-
-&nbsp;
-
-## [Untagged] - May 23, 2026 12:10:24 AM
-
-Commit [7eeaf148a1087d688b00f9007f7937a41cd3a71f](https://github.com/StoneCypher/better_git_changelog/commit/7eeaf148a1087d688b00f9007f7937a41cd3a71f)
-
-Author: `John Haugeland <stonecypher@gmail.com>`
-
-  * ci: run the test suite in CI
-  * The build step was named "npm install, build, and test" but its body
-only ran `npm install && npm run build`, so assertions never executed
-on push. This is the root pattern that let the 3+ parent Merge: row
-bug ship in 1.6.3 without local catch.
-  * Append `&& npm test` to the run line so the full node:test suite
-runs on every push across the existing node/OS matrix. The step
-name is now accurate.
-  * Closes #23

--- a/README.md
+++ b/README.md
@@ -4,15 +4,38 @@ Make a changelog from your git commits, tags, and releases — zero config.
 
 [![Node.js CI](https://github.com/StoneCypher/better_git_changelog/actions/workflows/node.js.yml/badge.svg)](https://github.com/StoneCypher/better_git_changelog/actions/workflows/node.js.yml)
 [![npm](https://img.shields.io/npm/v/better_git_changelog.svg)](https://www.npmjs.com/package/better_git_changelog)
+[![types included](https://img.shields.io/badge/types-included-blue)](#programmatic-use)
+[![license: MIT](https://img.shields.io/badge/license-MIT-green)](#license)
 
-```
+```sh
 npm install --save-dev better_git_changelog
+# or:
+#   pnpm add -D better_git_changelog
+#   yarn add -D better_git_changelog
+#   bun  add -d better_git_changelog
+
 better_git_changelog
 ```
 
 Run it inside any git repository and it writes a `CHANGELOG.md` from your
 project history — the full history by default, or pass `-b` to additionally
 emit a short summary alongside a complete `CHANGELOG.long.md`.
+
+&nbsp; 
+
+&nbsp; 
+
+# Contents
+
+- [What's this, then?](#whats-this-then)
+- [Usage](#usage)
+- [Languages](#languages)
+- [Programmatic use](#programmatic-use)
+- [How it works](#how-it-works)
+- [Requirements](#requirements)
+- [What does it look like?](#what-does-it-look-like)
+- [Development](#development)
+- [License](#license)
 
 &nbsp; 
 
@@ -104,9 +127,11 @@ better_git_changelog --changelog-lang fr --translator claude
 
 By default only the changelog's boilerplate is localized; commit messages are
 left as written. Passing `--translator` (together with `--changelog-lang`) also
-translates the commit text. `claude` is a built-in preset; any other value is
-the name of an executable, which is run with the target language code as its
-argument and receives the text to translate on standard input.
+translates the commit text. `claude` is a built-in preset that shells out to
+the [Claude CLI](https://docs.anthropic.com/en/docs/claude-code) — install it
+and make sure `claude` is on your `PATH` before using the preset. Any other
+value is the name of an executable, which is run with the target language code
+as its argument and receives the text to translate on standard input.
 
 &nbsp; 
 
@@ -114,23 +139,75 @@ argument and receives the text to translate on standard input.
 
 # Programmatic use
 
-The package also exports its internals, so you can drive it from code:
+The package also exports its internals, so you can drive it from code. Use
+whichever import style your project prefers:
 
 ```js
+// CommonJS
 const changelog = require('better_git_changelog');
 
-// write the files directly
+// ESM
+import * as changelog from 'better_git_changelog';
+```
+
+Write the standard files directly:
+
+```js
 changelog.write_short_md('CHANGELOG.md', false, 10);
 changelog.write_long_md('CHANGELOG.long.md');
+```
 
-// or work with the data yourself
-const data     = changelog.scan();              // { tag_list, tag_hashes, reflog, not_found }
+…or work with the data yourself:
+
+```js
+const data     = changelog.scan();
+// { tag_list, tag_hashes, reflog, not_found, repo_url }
+
 const markdown = changelog.convert_to_md({ data });
 ```
 
-Other exports include `parse_rl`, `get_tag_list`, `tag_to_hash`,
-`tags_to_hashes`, `convert_to_json`, and the `default_formatter` /
-`default_separator` hooks used to customize the rendered output.
+## TypeScript
+
+Type declarations ship with the package at `dist/types/index.d.ts`. No separate
+`@types/*` install is required — types resolve automatically when you import
+from the package:
+
+```ts
+import {
+  scan,
+  convert_to_md,
+  type ReflogEntry,
+  type ScanResult,
+} from 'better_git_changelog';
+
+const data:   ScanResult     = scan();
+const md:     string         = convert_to_md({ data });
+const merges: ReflogEntry[]  = data.reflog.filter(e => e.merge);
+```
+
+## Public exports
+
+| Export | Description |
+|--------|-------------|
+| `scan()` | Scan the current repository; returns `{ tag_list, tag_hashes, reflog, not_found, repo_url }`. |
+| `write_short_md(target, has_both, short_length, longname, data?, translator?)` | Scan and write the short-form `CHANGELOG.md`. |
+| `write_long_md(target, data?, translator?)` | Scan and write the full-history `CHANGELOG.long.md`. |
+| `convert_to_md({ data, … })` | Render a `ScanResult` as a Markdown changelog string. |
+| `convert_to_json({ target, data })` | Serialize a `ScanResult` to a JSON file. |
+| `default_formatter(item, tr?, repo_url?)` | Default per-entry Markdown renderer; pass a replacement via `convert_to_md`. |
+| `default_separator()` | Default inter-entry separator; pass a replacement via `convert_to_md`. |
+| `parse_rl(input)` | Parse raw `git log --reflog` text into `ReflogEntry[]`. |
+| `get_reflog_data()` | Run `git log --reflog` and return the raw output ready for `parse_rl`. |
+| `get_tag_list()` | List every tag name in the repository. |
+| `tag_to_hash(tag)` | Resolve one tag name to its commit hash. |
+| `tags_to_hashes(tags)` | Resolve a set of tag names to a `Map<name, hash>` in a single git call. |
+| `get_tags_as_hashes()` | List every tag and resolve all of them to hashes. |
+| `get_remote_url()` | Read the `origin` remote URL, or `null`. |
+| `remote_to_web_url(remote)` | Convert a git remote URL into a `https://host/owner/repo` web base, or `null`. |
+| `slug(text)` | Turn a tag name into an HTML-anchor-safe slug. |
+| `ReflogEntry` *(type)* | One parsed commit entry from the reflog. |
+| `ScanResult` *(type)* | Complete scan result (the value `scan()` returns). |
+| `ScanAllResult` *(type)* | Subset returned by the internal `scan_all`. |
 
 &nbsp; 
 
@@ -153,6 +230,7 @@ Other exports include `parse_rl`, `get_tag_list`, `tag_to_hash`,
 - **Node.js 14 or newer**
 - **git** available on your `PATH` — the tool shells out to it
 - Run it from inside a git repository
+- **TypeScript users:** type declarations ship at `dist/types/index.d.ts`; no `@types/*` package is required
 
 &nbsp; 
 
@@ -160,7 +238,44 @@ Other exports include `parse_rl`, `get_tag_list`, `tag_to_hash`,
 
 # What does it look like?
 
-[There's an example here](https://github.com/StoneCypher/jssm/blob/main/CHANGELOG.md).
+A tagged release in the generated `CHANGELOG.md` looks like this:
+
+```markdown
+<a name="1__6__18" />
+
+## [1.6.18] - May 23, 2026 1:55:54 AM
+
+Commit [94d66c7b9a052c2ab3c3736b1124e519891b95ad](https://github.com/StoneCypher/better_git_changelog/commit/94d66c7b9a052c2ab3c3736b1124e519891b95ad)
+
+Author: `John Haugeland <stonecypher@gmail.com>`
+
+Merges [2f14edb, 4ccc9b0]
+
+  * Merge pull request #31 from StoneCypher/fix_26-05-23_short-hash-variable-length_30
+  * fix: accept short hashes longer than 7 chars in Merge: rows
+```
+
+For a longer real-world example, see [jssm's CHANGELOG.md](https://github.com/StoneCypher/jssm/blob/main/CHANGELOG.md).
+
+&nbsp; 
+
+&nbsp; 
+
+# Development
+
+```sh
+npm install            # install dev dependencies
+npm run build          # regenerate the PEG parser, run tsc, self-emit CHANGELOG.md
+npm test               # all tests
+npm run test:unit      # unit tests only
+npm run test:property  # fast-check property tests only
+npm run coverage       # test run with V8 coverage
+```
+
+The reflog parser is generated from
+[`src/peg/reflog_parser.peg`](src/peg/reflog_parser.peg) into
+`src/js/reflog_parser.js` by `npm run peg`. The generated `.js` is committed
+and stays in sync with the `.peg` source via the `build` script.
 
 &nbsp; 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "better_git_changelog",
-  "version": "1.6.19",
+  "version": "1.6.20",
   "description": "Make a changelog from git commits, tags, and releases",
   "main": "src/js/index.js",
   "types": "./dist/types/index.d.ts",


### PR DESCRIPTION
## Summary

Brings the README up to date with the type-declarations work shipped in #21 (commit 2c338a7) and a handful of related quality-of-life improvements.

- Add a table of contents.
- Multi-package-manager install snippet (npm / pnpm / yarn / bun).
- Expand **Programmatic use** to cover CommonJS, ESM, and TypeScript with typed imports against `dist/types/index.d.ts`.
- Replace the trailing *"Other exports include..."* paragraph with a **public exports table** sourced from `src/js/index.js` — surfaces previously unmentioned functions (`scan`, `convert_to_md`, `get_remote_url`, `remote_to_web_url`, `slug`, `get_tags_as_hashes`) and the exported types (`ReflogEntry`, `ScanResult`, `ScanAllResult`).
- Add an inline example of generated output (real `1.6.18` entry lifted from `CHANGELOG.long.md`) alongside the existing jssm link.
- New **Development** section documenting `npm install`, `npm run build`, `npm test`, `npm run test:unit`, `npm run test:property`, `npm run coverage`, and the PEG -> JS generation pipeline.
- Note that `--translator claude` requires the Claude CLI installed and on `PATH`.
- Add *types included* and *license: MIT* badges.
- Add a TypeScript-users note to **Requirements**.

No source changes. `CHANGELOG.md` / `CHANGELOG.long.md` updates are the usual build-output regeneration.

## Test plan

- [x] `npm run build` green (clean -> peg -> check-locales -> tsc -> check-dts -> self)
- [x] No IDE diagnostics on `README.md`
- [ ] Render the README on the PR page and verify the TOC anchors all resolve
- [ ] Confirm badge URLs load (CI, npm, types, license)